### PR TITLE
Avoid collision with token upload from spi controller

### DIFF
--- a/controllers/tokenupload_controller.go
+++ b/controllers/tokenupload_controller.go
@@ -106,14 +106,7 @@ func (r *TokenUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// on the non-nil DeletionTimestamp. Therefore, in case of errors, we just create the error event and
 	// return a "success" to the controller runtime.
 
-	secretType := uploadSecret.GetLabels()[tokenSecretLabel]
-	switch secretType {
-	case "remotesecret":
-		err = r.reconcileRemoteSecret(ctx, uploadSecret)
-	default:
-		err = fmt.Errorf("%w: %s", invalidSecretTypeError, secretType)
-		lg.Error(err, "invalid secret type")
-	}
+	err = r.reconcileRemoteSecret(ctx, uploadSecret)
 
 	if err != nil {
 		r.createErrorEvent(ctx, uploadSecret, err, lg)


### PR DESCRIPTION
### What does this PR do?
 - matches the exact value of `"spi.appstudio.redhat.com/upload-secret"` label to avoid collision with token upload from spi controller. 
 - Do not delete unknown types of secret with  `"spi.appstudio.redhat.com/upload-secret". For example with the type `token`

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-494


### How to test this PR?
- create upload secret with type `token`
```
echo 'Uploading github token'
cat <<EOF | kubectl apply -n $TARGET_NAMESPACE -f -
apiVersion: v1
kind: Secret
metadata:
  name: test-secret
  labels:
    spi.appstudio.redhat.com/upload-secret: token
type: Opaque
stringData:
  spiTokenName: my-spi-access-token
  providerUrl: https://github.com/
  tokenData: ${GITHUB_SPI}
EOF
```