### PR TITLE
Ignore latest-tag kube-linter check

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -8,6 +8,11 @@ namespace: remotesecret
 # field above.
 namePrefix: remote-secret-
 
+images:
+  - name: quay.io/redhat-appstudio/remote-secret-controller
+    newName: quay.io/redhat-appstudio/remote-secret-controller
+    newTag: latest
+
 resources:
 - ../crd
 - ../rbac


### PR DESCRIPTION
### What does this PR do?
Ignore latest-tag kube-linter check. Replacing `latest` with `next` is just a way to hide the problem. Until a better idea would be found I think we can add this check to ignore. In any case on prod/stage we use sha based tags.

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
kube-linter complains
```
<standard input>: (object: remotesecret/remote-secret-controller-manager apps/v1, Kind=Deployment) The container "manager" is using an invalid container image, "quay.io/redhat-appstudio/remote-secret-controller". Please use images that are not blocked by the `BlockList` criteria : [".*:(latest)$" "^[^:]*$" "(.*/[^:]+)$"] (check: latest-tag, remediation: Use a container image with a specific tag other than latest.)


```

### How to test this PR?
```
 kustomize build config/overlays/openshift_aws | kube-linter lint --config ./.github/.kube-linter-config.yaml  -  
```