### PR TITLE
enable to easily override the image organization to build custom images during the development.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,16 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
+# IMG_BASE defines the domain and organization of the image being built. Overriding this enables
+# one to succintly generate personal images during development.
+IMG_BASE ?= quay.io/redhat-appstudio
+
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # example.com/remote-secret-bundle:$VERSION and example.com/remote-secret-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/redhat-appstudio/remote-secret
+IMAGE_TAG_BASE ?= $(IMG_BASE)/remote-secret
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)


### PR DESCRIPTION
### What does this PR do?
enable building the images using:
```
make docker-build docker-push IMG_BASE=quay.io/lkrejci TAG_NAME=svpi-506
```

i.e. it enables to override just the domain and organization of the docker image url.