### PR TITLE
Fix nil pointer dereferences

### DIFF
--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -432,9 +432,15 @@ func (r *RemoteSecretReconciler) deleteFromNamespace(ctx context.Context, remote
 }
 
 func (r *RemoteSecretReconciler) newDependentsHandler(remoteSecret *api.RemoteSecret, targetSpec *api.RemoteSecretTarget, targetStatus *api.TargetStatus) bindings.DependentsHandler[*api.RemoteSecret] {
+	var apiUrl string
+	if targetSpec != nil {
+		apiUrl = targetSpec.ApiUrl
+	} else if targetStatus != nil {
+		apiUrl = targetStatus.ApiUrl
+	}
 	return bindings.DependentsHandler[*api.RemoteSecret]{
 		Target: &namespacetarget.NamespaceTarget{
-			Client:       r.clientForTarget(targetSpec),
+			Client:       r.clientForUrl(apiUrl),
 			TargetKey:    client.ObjectKeyFromObject(remoteSecret),
 			SecretSpec:   &remoteSecret.Spec.Secret,
 			TargetSpec:   targetSpec,
@@ -447,8 +453,8 @@ func (r *RemoteSecretReconciler) newDependentsHandler(remoteSecret *api.RemoteSe
 	}
 }
 
-func (r *RemoteSecretReconciler) clientForTarget(targetSpec *api.RemoteSecretTarget) client.Client {
-	if targetSpec.ApiUrl == "" {
+func (r *RemoteSecretReconciler) clientForUrl(apiUrl string) client.Client {
+	if apiUrl == "" {
 		return r.Client
 	}
 


### PR DESCRIPTION
### What does this PR do?
This fixes two sources of NPEs in the codebase.

First one would happen when a target that was previously deployed to (and therefore had an entry in the status) would be removed from the spec.

The second one would happen when when there were some entries in the status marking the duplicates and a target corresponding to a status entry preceding these duplicate-marking entries would be removed from the spec.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-506

### How to test this PR?
The first kind of NPE:
1. create a remote secret with 2 targets
2. upload the secret data for the remote secret
3. remove one of the targets from the remote secret
4. the controller should not crash

The second kind of NPE:
1. create a remote secret with one unique target as the first entry and 2 identical targets as the second and the third entry
2. upload the data to the remote secret
3. make sure that the remote secret status mentions the targets in the same order as the spec.
4. remove the first target from the spec
5. the controller should not crash.
