### PR TITLE
Don't requeue reconcile on inconsistent targets

### DIFF
--- a/controllers/bindings/dependents.go
+++ b/controllers/bindings/dependents.go
@@ -16,6 +16,7 @@ package bindings
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cenkalti/backoff/v4"
@@ -23,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var DependentsInconsistencyError = errors.New("inconsistency detected when deploying dependent objects")
 
 // DependentsHandler is taking care of the dependent objects of the provided target.
 type DependentsHandler[K any] struct {

--- a/controllers/bindings/serviceaccounts.go
+++ b/controllers/bindings/serviceaccounts.go
@@ -16,7 +16,6 @@ package bindings
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
 
 	api "github.com/redhat-appstudio/remote-secret/api/v1beta1"
@@ -27,9 +26,9 @@ import (
 )
 
 var (
-	specInconsistentWithStatusError              = stderrors.New("the number of service accounts in the spec doesn't correspond to the number of found service accounts")
-	managedServiceAccountAlreadyExists           = stderrors.New("a service account with same name as the managed one already exists")
-	managedServiceAccountManagedByAnotherBinding = stderrors.New("the service account already exists and is managed by another binding object")
+	specInconsistentWithStatusError              = fmt.Errorf("%w: the number of service accounts in the spec doesn't correspond to the number of found service accounts", DependentsInconsistencyError)
+	managedServiceAccountAlreadyExists           = fmt.Errorf("%w: a service account with same name as the managed one already exists", DependentsInconsistencyError)
+	managedServiceAccountManagedByAnotherBinding = fmt.Errorf("%w: the service account already exists and is managed by another binding object", DependentsInconsistencyError)
 )
 
 const (

--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -432,9 +432,15 @@ func (r *RemoteSecretReconciler) deleteFromNamespace(ctx context.Context, remote
 }
 
 func (r *RemoteSecretReconciler) newDependentsHandler(remoteSecret *api.RemoteSecret, targetSpec *api.RemoteSecretTarget, targetStatus *api.TargetStatus) bindings.DependentsHandler[*api.RemoteSecret] {
+	var apiUrl string
+	if targetSpec != nil {
+		apiUrl = targetSpec.ApiUrl
+	} else if targetStatus != nil {
+		apiUrl = targetStatus.ApiUrl
+	}
 	return bindings.DependentsHandler[*api.RemoteSecret]{
 		Target: &namespacetarget.NamespaceTarget{
-			Client:       r.clientForTarget(targetSpec),
+			Client:       r.clientForUrl(apiUrl),
 			TargetKey:    client.ObjectKeyFromObject(remoteSecret),
 			SecretSpec:   &remoteSecret.Spec.Secret,
 			TargetSpec:   targetSpec,
@@ -447,8 +453,8 @@ func (r *RemoteSecretReconciler) newDependentsHandler(remoteSecret *api.RemoteSe
 	}
 }
 
-func (r *RemoteSecretReconciler) clientForTarget(targetSpec *api.RemoteSecretTarget) client.Client {
-	if targetSpec.ApiUrl == "" {
+func (r *RemoteSecretReconciler) clientForUrl(apiUrl string) client.Client {
+	if apiUrl == "" {
 		return r.Client
 	}
 


### PR DESCRIPTION
### What does this PR do?
Don't try to repeat the reconciliation when we detect that the target is in an inconsistent state (a managed SA already exists, a managed SA is already managed by another remote secret)

### What issues does this PR fix or reference?
none