### PR TITLE
Make `make run` debuggable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,9 @@ build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+run: manifests generate fmt vet build ## Run a controller from your host using Vault running in the cluster (assumes ones of the deploy_* targets has been applied)
+	hack/persist_vault_creds_in_tmp.sh
+	ZAPDEVEL=true VAULTHOST="https://vault.$(shell minikube ip).nip.io" VAULTAPPROLEROLEIDFILEPATH="./.tmp/role_id" VAULTAPPROLESECRETIDFILEPATH="./.tmp/secret_id" VAULTINSECURETLS=true bin/manager
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.

--- a/hack/persist_vault_creds_in_tmp.sh
+++ b/hack/persist_vault_creds_in_tmp.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+mkdir -p .tmp/
+SECRET=$(kubectl get -n remotesecret secret vault-approle-remote-secret-operator -o json)
+
+echo "$SECRET" | jq -r ".data.role_id" | base64 -d > .tmp/role_id
+echo "$SECRET" | jq -r ".data.secret_id" | base64 -d > .tmp/secret_id
+


### PR DESCRIPTION
### What does this PR do?
Modify the `run` make target so that it is properly set up with vault auth and can be remotely debugged.
