### PR TITLE
Handle the discrepancy between the spec and the actual cluster state when the secret in the spec is renamed

### DIFF
--- a/controllers/bindings/namechecks.go
+++ b/controllers/bindings/namechecks.go
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bindings
+
+import "strings"
+
+// NameCorresponds is a simple helper function to figure out whether the provided
+// `actualName` can be a name of an K8s object with the provided `specificName` (`metadata.name`)
+// or `generateName` (`metadata.generateName`).
+//
+// The equality of the actualName with the specificName is determined first and only then
+// the generateName is considered. This is to conform with the behavior of the cluster
+// (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/).
+func NameCorresponds(actualName, specificName, generateName string) bool {
+	if specificName != "" {
+		return actualName == specificName
+	}
+
+	return generateName != "" && strings.HasPrefix(actualName, generateName)
+}

--- a/controllers/bindings/namechecks_test.go
+++ b/controllers/bindings/namechecks_test.go
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bindings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNameCorresponds(t *testing.T) {
+	t.Run("name check has precedence", func(t *testing.T) {
+		// Kubernetes docs (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/) specify that generateName is only taken into account if the name is not
+		// specified. We need to behave the same.
+		assert.True(t, NameCorresponds("a", "a", "asdf"))
+		assert.False(t, NameCorresponds("a-", "b", "a-suffix"))
+	})
+
+	t.Run("name check with empty generateName", func(t *testing.T) {
+		assert.True(t, NameCorresponds("a", "a", ""))
+		assert.False(t, NameCorresponds("a", "", ""))
+	})
+
+	t.Run("uses generate if name empty", func(t *testing.T) {
+		assert.True(t, NameCorresponds("a", "", "a"))
+		assert.True(t, NameCorresponds("afbsfdf", "", "a"))
+		assert.False(t, NameCorresponds("a", "", "b"))
+		assert.False(t, NameCorresponds("abbasdf", "", "b"))
+	})
+}


### PR DESCRIPTION
### What does this PR do?
`$TITLE`. This updates the SA links to the secret and removes the "stale" secret when there is a discrepancy between the name of the secret in the spec and the actual name of the secret in the target.

This is done by first creating the new secret, then linking it to the SA(s), removing the link to the old secret from the SA(s) and finally removing the stale old secret.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-487


### How to test this PR?
Follow the repro steps in the issue https://issues.redhat.com/browse/SVPI-487.