### PR TITLE
Stabilize reconciliation when using the default secret name

### DIFF
--- a/controllers/bindings/namechecks.go
+++ b/controllers/bindings/namechecks.go
@@ -28,5 +28,11 @@ func NameCorresponds(actualName, specificName, generateName string) bool {
 		return actualName == specificName
 	}
 
-	return generateName != "" && strings.HasPrefix(actualName, generateName)
+	if generateName != "" {
+		return strings.HasPrefix(actualName, generateName)
+	}
+
+	// both specific name and generate name are empty. This means that the actualName just is
+	// what it is and so we can only say that it corresponds to itself.
+	return true
 }

--- a/controllers/bindings/namechecks_test.go
+++ b/controllers/bindings/namechecks_test.go
@@ -25,12 +25,12 @@ func TestNameCorresponds(t *testing.T) {
 		// Kubernetes docs (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/) specify that generateName is only taken into account if the name is not
 		// specified. We need to behave the same.
 		assert.True(t, NameCorresponds("a", "a", "asdf"))
-		assert.False(t, NameCorresponds("a-", "b", "a-suffix"))
+		assert.False(t, NameCorresponds("a-suffix", "b", "a-"))
 	})
 
 	t.Run("name check with empty generateName", func(t *testing.T) {
 		assert.True(t, NameCorresponds("a", "a", ""))
-		assert.False(t, NameCorresponds("a", "", ""))
+		assert.False(t, NameCorresponds("a", "b", ""))
 	})
 
 	t.Run("uses generate if name empty", func(t *testing.T) {
@@ -38,5 +38,9 @@ func TestNameCorresponds(t *testing.T) {
 		assert.True(t, NameCorresponds("afbsfdf", "", "a"))
 		assert.False(t, NameCorresponds("a", "", "b"))
 		assert.False(t, NameCorresponds("abbasdf", "", "b"))
+	})
+
+	t.Run("corresponds if no requirements given", func(t *testing.T) {
+		assert.True(t, NameCorresponds("a", "", ""))
 	})
 }


### PR DESCRIPTION
### What does this PR do?
fix the NameCorresponds to also handle the default name when there are no other requirements on the name of the secret (neither the name, nor generateName is given in the spec).

Note that this is an actual bug in remote secrets that would cause an infinite reconciliation if the spec.secret is empty.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-524


### How to test this PR?
1. create a remote secret with empty `spec.secret`, i.e.:
   ```yaml
   apiVersion: appstudio.redhat.com/v1beta1
   kind: RemoteSecret
   metadata:
     name: test-remotesecret
   spec:
     secret: {}
   targets:
   - namespace: test-target-namespace
   ```
2. Check that name of the secret deployed in the target remains stable.

You can use this image for manual testing: `quay.io/lkrejci/remote-secret-controller:svpi-524`