### PR TITLE
Return less error verbosity from AWS storage into RemoteSecret status

### DIFF
--- a/pkg/secretstorage/awsstorage/aws.go
+++ b/pkg/secretstorage/awsstorage/aws.go
@@ -103,16 +103,18 @@ func (s *AwsSecretStorage) Get(ctx context.Context, id secretstorage.SecretID) (
 					dbgLog.Info("secret successfully migrated", "secretid", id)
 					return secretData, nil
 				} else {
-					dbgLog.Info("secret not found in aws storage", "err", notFoundErr.ErrorMessage())
-					return nil, fmt.Errorf("%w: %s", secretstorage.NotFoundError, notFoundErr.Error())
+					dbgLog.Info("secret not found in aws storage", "err", notFoundErr.Error())
+					return nil, fmt.Errorf("%w: %s", secretstorage.NotFoundError, notFoundErr.ErrorMessage())
 				}
 			}
 
 			if invalidRequestErr, ok := awsError.(*types.InvalidRequestException); ok {
-				return nil, fmt.Errorf("%w: %s", secretstorage.NotFoundError, invalidRequestErr.Error())
+				dbgLog.Info("invalid request to aws secret", "error", invalidRequestErr.Error())
+				return nil, fmt.Errorf("error when making request to aws: %s", invalidRequestErr.ErrorMessage())
 			}
 		}
 
+		dbgLog.Info("unknown error on reading aws secret", "error", err.Error())
 		return nil, fmt.Errorf("not able to get secret from the aws storage for some unknown reason: %w", err)
 	}
 

--- a/pkg/secretstorage/awsstorage/aws.go
+++ b/pkg/secretstorage/awsstorage/aws.go
@@ -114,8 +114,8 @@ func (s *AwsSecretStorage) Get(ctx context.Context, id secretstorage.SecretID) (
 			}
 		}
 
-		dbgLog.Info("unknown error on reading aws secret", "error", err.Error())
-		return nil, fmt.Errorf("not able to get secret from the aws storage for some unknown reason: %w", err)
+		dbgLog.Info("unknown error on reading aws secret storage", "error", err.Error())
+		return nil, errors.New("not able to get secret from the aws storage for some unknown reason")
 	}
 
 	return getResult.SecretBinary, nil

--- a/pkg/secretstorage/awsstorage/aws_test.go
+++ b/pkg/secretstorage/awsstorage/aws_test.go
@@ -267,6 +267,7 @@ func TestGet(t *testing.T) {
 
 		data, err := strg.Get(ctx, testSecretID)
 		assert.Error(t, err)
+		assert.Equal(t, "not able to get secret from the aws storage for some unknown reason", err.Error())
 		assert.True(t, cl.getCalled)
 		assert.Nil(t, data)
 	})
@@ -276,7 +277,7 @@ func TestGet(t *testing.T) {
 
 		cl := &mockAwsClient{
 			getFn: func(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
-				return nil, &types.ResourceNotFoundException{}
+				return nil, &types.ResourceNotFoundException{Message: aws.String("no such key exists")}
 			},
 		}
 
@@ -287,6 +288,7 @@ func TestGet(t *testing.T) {
 		data, err := strg.Get(ctx, testSecretID)
 		assert.Error(t, err)
 		assert.Error(t, err, secretstorage.NotFoundError)
+		assert.Equal(t, "not found: no such key exists", err.Error())
 		assert.True(t, cl.getCalled)
 		assert.Nil(t, data)
 	})
@@ -306,6 +308,7 @@ func TestGet(t *testing.T) {
 
 		data, err := strg.Get(ctx, testSecretID)
 		assert.Error(t, err)
+		assert.Equal(t, "invalid request reported when making request to aws. message: token is scheduled for deletion", err.Error())
 		assert.Error(t, err, secretstorage.NotFoundError)
 		assert.True(t, cl.getCalled)
 		assert.Nil(t, data)


### PR DESCRIPTION
### What does this PR do?

Move most of error details into log, return only general message in the error object.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-521

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
