### PR TITLE
Fix for update-repo-script

### DIFF
--- a/.tekton/controller-pull-request.yaml
+++ b/.tekton/controller-pull-request.yaml
@@ -22,19 +22,6 @@ spec:
       value: "{{revision}}"
     - name: output-image
       value: "quay.io/redhat-appstudio/pull-request-builds:remote-secret-controller-{{pull_request_number}}"
-    - name: update-repo-script
-      value: |
-        yum install -y --setopt=tsflags=nodocs wget;
-        rm -rf /usr/local/go;
-        cd /tmp;
-        wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz;
-        tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz;
-        export PATH=$PATH:/usr/local/go/bin;
-        go version;
-        ls -la;
-        ./hack/set-remote-secret.sh {{ revision }} ;
-    - name: update-repo-name
-      value: redhat-appstudio/service-provider-integration-operator
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest

--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -29,7 +29,13 @@ spec:
         awk  -i inplace -v n=1 '/newTag:/ { if (++count == n) sub(/newTag:.*/, "newTag: {{ revision }}")} 1' components/remote-secret-controller/overlays/staging/base/kustomization.yaml
     - name: update-repo-script
       value: |
-        INSTALL_PKGS="go-toolset" &&  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && rpm -V $INSTALL_PKGS;
+        yum install -y --setopt=tsflags=nodocs wget;
+        rm -rf /usr/local/go;
+        cd /tmp;
+        wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz;
+        tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz;
+        export PATH=$PATH:/usr/local/go/bin;
+        go version;
         ./hack/set-remote-secret.sh {{ revision }} ;
     - name: update-repo-name
       value: redhat-appstudio/service-provider-integration-operator


### PR DESCRIPTION
### What does this PR do?
Manually install go1.20

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
- ubi repository contains only 1.19. But https://github.com/redhat-appstudio/service-provider-integration-operator uses go 1.20


### How to test this PR?
n/a
