### PR TITLE
Remove target type, make target namespace optional in upload secrets

### DIFF
--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/controllers/tokenupload_controller.go
+++ b/controllers/tokenupload_controller.go
@@ -47,7 +47,7 @@ import (
 const (
 	uploadSecretLabel          = "appstudio.redhat.com/upload-secret"     //#nosec G101 -- false positive, this is not a token
 	remoteSecretNameAnnotation = "appstudio.redhat.com/remotesecret-name" //#nosec G101 -- false positive, this is not a token
-	targetNameAnnotation       = "appstudio.redhat.com/remotesecret-target-name"
+	targetNamespaceAnnotation  = "appstudio.redhat.com/remotesecret-target-namespace"
 )
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;delete
@@ -229,7 +229,7 @@ func (r *TokenUploadReconciler) createRemoteSecret(ctx context.Context, uploadSe
 		Spec: api.RemoteSecretSpec{},
 	}
 
-	targetName, ok := uploadSecret.Annotations[targetNameAnnotation]
+	targetName, ok := uploadSecret.Annotations[targetNamespaceAnnotation]
 	if ok {
 		targetSpec := api.RemoteSecretTarget{}
 		targetSpec.Namespace = targetName

--- a/controllers/tokenupload_controller.go
+++ b/controllers/tokenupload_controller.go
@@ -48,12 +48,10 @@ import (
 const (
 	uploadSecretLabel          = "appstudio.redhat.com/upload-secret"     //#nosec G101 -- false positive, this is not a token
 	remoteSecretNameAnnotation = "appstudio.redhat.com/remotesecret-name" //#nosec G101 -- false positive, this is not a token
-	targetTypeAnnotation       = "appstudio.redhat.com/remotesecret-target-type"
 	targetNameAnnotation       = "appstudio.redhat.com/remotesecret-target-name"
 )
 
 var (
-	targetTypeNotSetError = stdErrors.New("target type not set")
 	targetNameNotSetError = stdErrors.New("target name not set")
 )
 
@@ -228,30 +226,22 @@ func (r *TokenUploadReconciler) findRemoteSecret(ctx context.Context, uploadSecr
 }
 
 func (r *TokenUploadReconciler) createRemoteSecret(ctx context.Context, uploadSecret *corev1.Secret, lg logr.Logger) (*api.RemoteSecret, error) {
-	targetType, ok := uploadSecret.Annotations[targetTypeAnnotation]
-	if !ok {
-		return nil, targetTypeNotSetError
-	}
-	targetName, ok := uploadSecret.Annotations[targetNameAnnotation]
-	if !ok {
-		return nil, targetNameNotSetError
-	}
-	remoteSecretName := uploadSecret.Annotations[remoteSecretNameAnnotation]
-
-	targetSpec := api.RemoteSecretTarget{}
-	if targetType == "namespace" {
-		targetSpec.Namespace = targetName
-	}
 
 	remoteSecret := api.RemoteSecret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: uploadSecret.Namespace,
 		},
-		Spec: api.RemoteSecretSpec{
-			Targets: []api.RemoteSecretTarget{targetSpec},
-		},
+		Spec: api.RemoteSecretSpec{},
 	}
 
+	targetName, ok := uploadSecret.Annotations[targetNameAnnotation]
+	if ok {
+		targetSpec := api.RemoteSecretTarget{}
+		targetSpec.Namespace = targetName
+		remoteSecret.Spec.Targets = []api.RemoteSecretTarget{targetSpec}
+	}
+
+	remoteSecretName := uploadSecret.Annotations[remoteSecretNameAnnotation]
 	if remoteSecretName == "" {
 		remoteSecret.GenerateName = "generated-"
 	} else {
@@ -260,7 +250,7 @@ func (r *TokenUploadReconciler) createRemoteSecret(ctx context.Context, uploadSe
 
 	err := r.Create(ctx, &remoteSecret)
 	if err == nil {
-		lg.V(logs.DebugLevel).Info("RemoteSecret created : ", "RemoteSecret.name", remoteSecret.Name, "targetType", targetType, "targetName", targetName)
+		lg.V(logs.DebugLevel).Info("RemoteSecret created : ", "RemoteSecret.name", remoteSecret.Name, "targetName", targetName)
 		return &remoteSecret, nil
 	} else {
 		return nil, fmt.Errorf("can not create RemoteSecret %s. Reason: %w", remoteSecret.Name, err)

--- a/controllers/tokenupload_controller.go
+++ b/controllers/tokenupload_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	stdErrors "errors"
 	"fmt"
 	"time"
 
@@ -49,10 +48,6 @@ const (
 	uploadSecretLabel          = "appstudio.redhat.com/upload-secret"     //#nosec G101 -- false positive, this is not a token
 	remoteSecretNameAnnotation = "appstudio.redhat.com/remotesecret-name" //#nosec G101 -- false positive, this is not a token
 	targetNameAnnotation       = "appstudio.redhat.com/remotesecret-target-name"
-)
-
-var (
-	targetNameNotSetError = stdErrors.New("target name not set")
 )
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;delete

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -99,6 +99,50 @@ status:
     secretName: db-credentials
 ```
 
+#### Creating RemoteSecret and target in a single action 
+
+If a remote secret is supposed to have only one simple target (containing namespace only), it can be created in a single operation by using a special annotation in the upload secret: 
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    name: upload-secret-data-for-remote-secret
+    namespace: default
+    labels:
+        appstudio.redhat.com/upload-secret: remotesecret
+        appstudio.redhat.com/remotesecret-target-namespace: abcd
+    annotations:
+        appstudio.redhat.com/remotesecret-name: test-remote-secret
+type: Opaque
+stringData:
+    username: u
+    password: passw0rd
+```
+The remote secret will be created and target from `appstudio.redhat.com/remotesecret-target-namespace` annotation will be set:
+
+```yaml
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+    name: test-remote-secret
+    namespace: default
+spec:
+    secret: {}
+    targets:
+    - namespace: abcd
+status:
+  conditions:
+  - lastTransitionTime: "..."
+    message: ""
+    reason: DataFound
+    status: "True"
+    type: DataObtained
+  targets:
+    - namespace: default
+      secretName: test-remote-secret-secret-2nb46
+```
+
 #### Define the structure of the secrets in the targets
 
 ```yaml

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -3,6 +3,7 @@ In this Manual we consider the main SPI use cases as well as give SPI API refere
 ## Table of Contents
 - [Use Cases](#use-cases)
     - [Delivering the secrets interactively](#delivering-the-secrets-interactively)
+    - [Creating RemoteSecret and target in a single action](#creating-remotesecret-and-target-in-a-single-action)
     - [Define the structure of the secrets in the targets](#define-the-structure-of-the-secrets-in-the-targets)
     - [Associating the secret with a service account in the targets](#associating-the-secret-with-a-service-account-in-the-targets)
     - [RemoteSecret has to be created with target namespace and Environment](#RemoteSecret-has-to-be-created-with-target-namespace-and-Environment)
@@ -99,7 +100,7 @@ status:
     secretName: db-credentials
 ```
 
-#### Creating RemoteSecret and target in a single action 
+#### Creating RemoteSecret and target in a single action
 
 If a remote secret is supposed to have only one simple target (containing namespace only), it can be created in a single operation by using a special annotation in the upload secret: 
 
@@ -111,9 +112,9 @@ metadata:
     namespace: default
     labels:
         appstudio.redhat.com/upload-secret: remotesecret
-        appstudio.redhat.com/remotesecret-target-namespace: abcd
     annotations:
         appstudio.redhat.com/remotesecret-name: test-remote-secret
+        appstudio.redhat.com/remotesecret-target-namespace: abcd
 type: Opaque
 stringData:
     username: u

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -139,7 +139,7 @@ status:
     status: "True"
     type: DataObtained
   targets:
-    - namespace: default
+    - namespace: abcd
       secretName: test-remote-secret-secret-2nb46
 ```
 

--- a/integration_tests/tokenuploadcontroller_test.go
+++ b/integration_tests/tokenuploadcontroller_test.go
@@ -75,7 +75,7 @@ var _ = Describe("TokenUploadController", func() {
 			BeforeEach(func() {
 				test.BeforeEach(ITest.Context, ITest.Client, nil)
 			})
-			
+
 			AfterEach(func() {
 				test.AfterEach(ITest.Context)
 			})

--- a/integration_tests/tokenuploadcontroller_test.go
+++ b/integration_tests/tokenuploadcontroller_test.go
@@ -99,6 +99,14 @@ var _ = Describe("TokenUploadController", func() {
 					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Name).To(Equal("new-remote-secret"))
 					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Spec.Targets[0].Namespace).To(Equal("ns"))
 				})
+				// due to a bug in crenv do a cleanup
+				Expect(ITest.Client.Delete(ITest.Context, &api.RemoteSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "new-remote-secret",
+						Namespace: "default",
+					},
+				})).To(Succeed())
+
 			})
 		})
 

--- a/integration_tests/tokenuploadcontroller_test.go
+++ b/integration_tests/tokenuploadcontroller_test.go
@@ -90,6 +90,13 @@ var _ = Describe("TokenUploadController", func() {
 			})
 
 			AfterEach(func() {
+				// due to a bug in crenv do a cleanup
+				Expect(ITest.Client.Delete(ITest.Context, &api.RemoteSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "new-remote-secret",
+						Namespace: "default",
+					},
+				})).To(Succeed())
 				test.AfterEach(ITest.Context)
 			})
 
@@ -99,13 +106,6 @@ var _ = Describe("TokenUploadController", func() {
 					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Name).To(Equal("new-remote-secret"))
 					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Spec.Targets[0].Namespace).To(Equal("ns"))
 				})
-				// due to a bug in crenv do a cleanup
-				Expect(ITest.Client.Delete(ITest.Context, &api.RemoteSecret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-remote-secret",
-						Namespace: "default",
-					},
-				})).To(Succeed())
 
 			})
 		})

--- a/integration_tests/tokenuploadcontroller_test.go
+++ b/integration_tests/tokenuploadcontroller_test.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrationtests
+
+import (
+	"github.com/metlos/crenv"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	api "github.com/redhat-appstudio/remote-secret/api/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("TokenUploadController", func() {
+	Describe("Upload token", func() {
+
+		When("no secret exists", func() {
+			test := crenv.TestSetup{
+				ToCreate: []client.Object{
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-remote-secret-upload",
+							Namespace: "default",
+							Labels: map[string]string{"appstudio.redhat.com/remotesecret-name": "new-remote-secret",
+								"appstudio.redhat.com/remotesecret-target-namespace": "mshaposh-tenant"},
+						},
+						Type: "Opaque",
+						Data: map[string][]byte{"a": []byte("b")},
+					},
+				},
+			}
+
+			BeforeEach(func() {
+				test.BeforeEach(ITest.Context, ITest.Client, nil)
+			})
+
+			AfterEach(func() {
+				test.AfterEach(ITest.Context)
+			})
+
+			It("creates new one", func() {
+				Eventually(func(g Gomega) {
+					Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)).To(HaveLen(1))
+					Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Name == "new-remote-secret").To(BeTrue())
+					Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Spec.Targets[0].Namespace == "mshaposh-tenant").To(BeTrue())
+				})
+			})
+		})
+
+	})
+
+})

--- a/integration_tests/tokenuploadcontroller_test.go
+++ b/integration_tests/tokenuploadcontroller_test.go
@@ -27,40 +27,7 @@ import (
 var _ = Describe("TokenUploadController", func() {
 	Describe("Upload token", func() {
 
-		When("no secret exists", func() {
-			test := crenv.TestSetup{
-				ToCreate: []client.Object{
-					&v1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-remote-secret-upload",
-							Namespace: "default",
-							Labels: map[string]string{"appstudio.redhat.com/remotesecret-name": "new-remote-secret",
-								"appstudio.redhat.com/remotesecret-target-namespace": "mshaposh-tenant"},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{"a": []byte("b")},
-					},
-				},
-			}
-
-			BeforeEach(func() {
-				test.BeforeEach(ITest.Context, ITest.Client, nil)
-			})
-
-			AfterEach(func() {
-				test.AfterEach(ITest.Context)
-			})
-
-			It("creates new one", func() {
-				Eventually(func(g Gomega) {
-					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)).To(HaveLen(1))
-					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Name).To(Equal("new-remote-secret"))
-					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Spec.Targets[0].Namespace).To(Equal("mshaposh-tenant"))
-				})
-			})
-		})
-
-		When("secret is exists", func() {
+		When("remote secret is exists", func() {
 			test := crenv.TestSetup{
 				ToCreate: []client.Object{
 					&api.RemoteSecret{
@@ -85,8 +52,9 @@ var _ = Describe("TokenUploadController", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-remote-secret-upload",
 						Namespace: "default",
-						Labels: map[string]string{"appstudio.redhat.com/remotesecret-name": "new-remote-secret",
-							"appstudio.redhat.com/remotesecret-target-namespace": "mshaposh-tenant"},
+						Labels:    map[string]string{"appstudio.redhat.com/upload-secret": "remotesecret"},
+						Annotations: map[string]string{"appstudio.redhat.com/remotesecret-name": "new-remote-secret",
+							"appstudio.redhat.com/remotesecret-target-namespace": "ns"},
 					},
 					Type: "Opaque",
 					Data: map[string][]byte{"a": []byte("b")},
@@ -95,7 +63,41 @@ var _ = Describe("TokenUploadController", func() {
 				Expect(ITest.Client.Create(ITest.Context, o)).To(Succeed())
 				Eventually(func(g Gomega) {
 					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)).To(HaveLen(1))
-					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Spec.Targets[0].Namespace).To(Equal("mshaposh-tenant"))
+					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Spec.Targets[0].Namespace).To(Equal("ns"))
+				})
+			})
+		})
+
+		When("no secret exists", func() {
+			test := crenv.TestSetup{
+				ToCreate: []client.Object{
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-remote-secret-upload",
+							Namespace: "default",
+							Labels:    map[string]string{"appstudio.redhat.com/upload-secret": "remotesecret"},
+							Annotations: map[string]string{"appstudio.redhat.com/remotesecret-name": "new-remote-secret",
+								"appstudio.redhat.com/remotesecret-target-namespace": "ns"},
+						},
+						Type: "Opaque",
+						Data: map[string][]byte{"a": []byte("b")},
+					},
+				},
+			}
+
+			BeforeEach(func() {
+				test.BeforeEach(ITest.Context, ITest.Client, nil)
+			})
+
+			AfterEach(func() {
+				test.AfterEach(ITest.Context)
+			})
+
+			It("creates new one", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)).To(HaveLen(1))
+					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Name).To(Equal("new-remote-secret"))
+					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Spec.Targets[0].Namespace).To(Equal("ns"))
 				})
 			})
 		})

--- a/integration_tests/tokenuploadcontroller_test.go
+++ b/integration_tests/tokenuploadcontroller_test.go
@@ -69,28 +69,30 @@ var _ = Describe("TokenUploadController", func() {
 							Namespace: "default",
 						},
 					},
-					&v1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-remote-secret-upload",
-							Namespace: "default",
-							Labels: map[string]string{"appstudio.redhat.com/remotesecret-name": "new-remote-secret",
-								"appstudio.redhat.com/remotesecret-target-namespace": "mshaposh-tenant"},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{"a": []byte("b")},
-					},
 				},
 			}
 
 			BeforeEach(func() {
 				test.BeforeEach(ITest.Context, ITest.Client, nil)
 			})
-
+			
 			AfterEach(func() {
 				test.AfterEach(ITest.Context)
 			})
 
 			It("adds new target", func() {
+				o := &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-remote-secret-upload",
+						Namespace: "default",
+						Labels: map[string]string{"appstudio.redhat.com/remotesecret-name": "new-remote-secret",
+							"appstudio.redhat.com/remotesecret-target-namespace": "mshaposh-tenant"},
+					},
+					Type: "Opaque",
+					Data: map[string][]byte{"a": []byte("b")},
+				}
+
+				Expect(ITest.Client.Create(ITest.Context, o)).To(Succeed())
 				Eventually(func(g Gomega) {
 					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)).To(HaveLen(1))
 					g.Expect(crenv.GetAll[*api.RemoteSecret](&test.InCluster)[0].Spec.Targets[0].Namespace).To(Equal("mshaposh-tenant"))

--- a/samples/remote-secret-from-secret.yaml
+++ b/samples/remote-secret-from-secret.yaml
@@ -9,8 +9,7 @@ metadata:
     appstudio.redhat.com/upload-secret: remotesecret
   annotations:
     appstudio.redhat.com/remotesecret-name: test-remote-secret
-    appstudio.redhat.com/remotesecret-target-type: namespace
-    appstudio.redhat.com/remotesecret-target-name: test-target-namespace
+    appstudio.redhat.com/remotesecret-target-namespace: test-target-namespace
 stringData:
   a: b
   c: d


### PR DESCRIPTION
### What does this PR do?
For remote secrets upload:
 - Remove `remotesecret-target-type` label;
 - Rename `remotesecret-target-name` to `remotesecret-target-namespace` and make it optional;

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-502

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
 
 Create upload secret w/out `remotesecret-target-type`  should be ok:
 
 ```
 apiVersion: v1
kind: Secret
metadata:
  name: test-remote-secret-from-secret
  labels:
    appstudio.redhat.com/upload-secret: remotesecret
  annotations:
    appstudio.redhat.com/remotesecret-name: test-remote-secret
    appstudio.redhat.com/remotesecret-target-namespace: default
stringData:
  a: b
  c: d
 ```
must create RemoteSecret with namespace set into target.

Creating wi/out namespace, must create RemoteSecret w/out targets:

``` 
 apiVersion: v1
kind: Secret
metadata:
  name: test-remote-secret-from-secret
  labels:
    appstudio.redhat.com/upload-secret: remotesecret
  annotations:
    appstudio.redhat.com/remotesecret-name: test-remote-secret
stringData:
  a: b
  c: d
 ```