### PR TITLE
Ensure that old secrets that were created by RemoteSecret are cleaned up

### DIFF
--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -313,7 +313,7 @@ func (r *RemoteSecretReconciler) processTargets(ctx context.Context, remoteSecre
 	}
 
 	for _, statusIndex := range namespaceClassification.Remove {
-		err := r.deleteFromNamespace(ctx, remoteSecret, int(statusIndex))
+		err := r.deleteFromNamespace(ctx, remoteSecret, statusIndex)
 		if err != nil {
 			errorAggregate.Add(err)
 		}
@@ -426,8 +426,8 @@ func (r *RemoteSecretReconciler) deployToNamespace(ctx context.Context, remoteSe
 	return rerror.AggregateNonNilErrors(syncErr, updateErr)
 }
 
-func (r *RemoteSecretReconciler) deleteFromNamespace(ctx context.Context, remoteSecret *api.RemoteSecret, targetStatusIndex int) error {
-	dep := r.newDependentsHandler(remoteSecret, nil, &remoteSecret.Status.Targets[targetStatusIndex])
+func (r *RemoteSecretReconciler) deleteFromNamespace(ctx context.Context, remoteSecret *api.RemoteSecret, statusTargetIndex remotesecrets.StatusTargetIndex) error {
+	dep := r.newDependentsHandler(remoteSecret, nil, &remoteSecret.Status.Targets[statusTargetIndex])
 
 	if err := dep.Cleanup(ctx); err != nil {
 		return fmt.Errorf("failed to clean up dependent objects in the finalizer: %w", err)

--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -312,8 +312,8 @@ func (r *RemoteSecretReconciler) processTargets(ctx context.Context, remoteSecre
 		}
 	}
 
-	for statusIndex := range namespaceClassification.Remove {
-		err := r.deleteFromNamespace(ctx, remoteSecret, statusIndex)
+	for _, statusIndex := range namespaceClassification.Remove {
+		err := r.deleteFromNamespace(ctx, remoteSecret, int(statusIndex))
 		if err != nil {
 			errorAggregate.Add(err)
 		}

--- a/integration_tests/remotesecretcontroller_test.go
+++ b/integration_tests/remotesecretcontroller_test.go
@@ -158,7 +158,7 @@ var _ = Describe("RemoteSecret", func() {
 					g.Expect(rs.Status.Targets).To(HaveLen(1))
 					// check that the secret in targetA is still there but not in targetB
 					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-secret", Namespace: targetA}, &corev1.Secret{})).To(Succeed())
-					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-secret", Namespace: targetB}, &corev1.Secret{})).ToNot(Succeed())
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-secret", Namespace: targetB}, &corev1.Secret{})).Error()
 				})
 			})
 
@@ -180,7 +180,7 @@ var _ = Describe("RemoteSecret", func() {
 					rs = *crenv.First[*api.RemoteSecret](&test.InCluster)
 					g.Expect(rs.Status.Targets).To(HaveLen(1))
 					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-sa", Namespace: targetA}, &corev1.ServiceAccount{})).To(Succeed())
-					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-sa", Namespace: targetB}, &corev1.ServiceAccount{})).ToNot(Succeed())
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-sa", Namespace: targetB}, &corev1.ServiceAccount{})).Error()
 				})
 			})
 		})

--- a/integration_tests/remotesecretcontroller_test.go
+++ b/integration_tests/remotesecretcontroller_test.go
@@ -19,7 +19,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	api "github.com/redhat-appstudio/remote-secret/api/v1beta1"
+	"github.com/redhat-appstudio/remote-secret/controllers/remotesecretstorage"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -85,6 +88,101 @@ var _ = Describe("RemoteSecret", func() {
 
 	Describe("Update", func() {
 		When("target removed", func() {
+			var test crenv.TestSetup
+			var targetA, targetB string
+
+			BeforeEach(func() {
+				targetA = string(uuid.NewUUID())
+				targetB = string(uuid.NewUUID())
+				Expect(ITest.Client.Create(ITest.Context, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: targetA},
+				})).To(Succeed())
+				Expect(ITest.Client.Create(ITest.Context, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: targetB},
+				})).To(Succeed())
+
+				test = crenv.TestSetup{
+					ToCreate: []client.Object{
+						&api.RemoteSecret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-remote-secret",
+								Namespace: "default",
+							},
+							Spec: api.RemoteSecretSpec{
+								Secret: api.LinkableSecretSpec{
+									Name: "injected-secret",
+									LinkedTo: []api.SecretLink{{
+										ServiceAccount: api.ServiceAccountLink{
+											Managed: api.ManagedServiceAccountSpec{
+												Name: "injected-sa",
+											},
+										}}},
+								},
+								Targets: []api.RemoteSecretTarget{{
+									Namespace: targetA,
+								}, {
+									Namespace: targetB,
+								}},
+							},
+						},
+					},
+				}
+
+				test.BeforeEach(ITest.Context, ITest.Client, nil)
+				rs := *crenv.First[*api.RemoteSecret](&test.InCluster)
+				Expect(rs).NotTo(BeNil())
+				Expect(ITest.Storage.Store(ITest.Context, rs, &remotesecretstorage.SecretData{
+					"a": []byte("b"),
+				})).To(Succeed())
+			})
+
+			AfterEach(func() {
+				test.AfterEach(ITest.Context)
+			})
+
+			It("should remove the target secret", func() {
+				// check that secret is created in each target
+				test.SettleWithCluster(ITest.Context, func(g Gomega) {
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-secret", Namespace: targetA}, &corev1.Secret{})).To(Succeed())
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-secret", Namespace: targetB}, &corev1.Secret{})).To(Succeed())
+				})
+
+				// now remove targetB from the spec
+				rs := *crenv.First[*api.RemoteSecret](&test.InCluster)
+				Expect(rs).NotTo(BeNil())
+				rs.Spec.Targets = []api.RemoteSecretTarget{{Namespace: targetA}}
+				Expect(ITest.Client.Update(ITest.Context, rs)).To(Succeed())
+
+				test.SettleWithCluster(ITest.Context, func(g Gomega) {
+					rs = *crenv.First[*api.RemoteSecret](&test.InCluster)
+					g.Expect(rs.Status.Targets).To(HaveLen(1))
+					// check that the secret in targetA is still there but not in targetB
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-secret", Namespace: targetA}, &corev1.Secret{})).To(Succeed())
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-secret", Namespace: targetB}, &corev1.Secret{})).ToNot(Succeed())
+				})
+			})
+
+			It("should remove the managed service account", func() {
+				// check that service account is created in each target
+				test.SettleWithCluster(ITest.Context, func(g Gomega) {
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-sa", Namespace: targetA}, &corev1.ServiceAccount{})).To(Succeed())
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-sa", Namespace: targetB}, &corev1.ServiceAccount{})).To(Succeed())
+				})
+
+				// now remove targetB from the spec
+				rs := *crenv.First[*api.RemoteSecret](&test.InCluster)
+				Expect(rs).NotTo(BeNil())
+				rs.Spec.Targets = []api.RemoteSecretTarget{{Namespace: targetA}}
+				Expect(ITest.Client.Update(ITest.Context, rs)).To(Succeed())
+
+				// check that the service account in targetA is still there but not in targetB
+				test.SettleWithCluster(ITest.Context, func(g Gomega) {
+					rs = *crenv.First[*api.RemoteSecret](&test.InCluster)
+					g.Expect(rs.Status.Targets).To(HaveLen(1))
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-sa", Namespace: targetA}, &corev1.ServiceAccount{})).To(Succeed())
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "injected-sa", Namespace: targetB}, &corev1.ServiceAccount{})).ToNot(Succeed())
+				})
+			})
 		})
 
 		When("target added", func() {


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where the secret and service account would not be deleted from the target namespace after the target namespace was removed from the remote secret spec.

Introduces integration tests that aim to $TITLE

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->
Bug replication example from jira:
![image](https://github.com/redhat-appstudio/remote-secret/assets/73115616/50fd9d5f-7d12-48a8-86b7-89810c20b7d6)


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-442

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
First, try to replicate the bug:
1. deploy RS operator from main `make deploy_minikube`
2. create target namespaces `kubectl create ns target-alpha` (same for target-bravo) 
3. create RS and upload a secret: 
```shell
cat <<EOF | kubectl create -n "default" -f -
apiVersion: appstudio.redhat.com/v1beta1
kind: RemoteSecret
metadata:
  name: test-remote-secret
spec:
  secret:
    generateName: secret-from-remote-
    linkedTo:
    - serviceAccount:  
        managed:
          generateName: sa-from-remote-
  targets:
  - namespace: target-alpha
  - namespace: target-bravo
EOF

cat <<EOF | kubectl create -n "default" -f -
apiVersion: v1
kind: Secret
metadata:
  name: test-remote-secret-secret
  labels:
    appstudio.redhat.com/upload-secret: remotesecret
  annotations:
    appstudio.redhat.com/remotesecret-name: test-remote-secret
type: Opaque
stringData:
  a: b
  c: d
EOF
```
4. Check the status of the RS and note what the second target namespace in the status is. Remove this target from the RS spec. So if the status shows:
```yaml
status:                      
  targets:                                                                                        
  - namespace: target-alpha                                                                       
    secretName: injected-secret                                                                  
    serviceAccountNames:                                                                       
    - injected-sa                                                                                
  - namespace: target-bravo                                                                     
    secretName: injected-secret                                                                
    serviceAccountNames:                                                                    
    - injected-sa 
```
Delete the `target-bravo` from spec.
6. Observe that the secret and service account is not deleted from this namespace.

Replace the RS operator image with `quay.io/pbaran/rs:SVPI-442-tests` and repeat the process. The secret and SA should be deleted.

To run the integration tests, run `make itest`
