### PR TITLE
feat: Reject UploadSecret if its type doesn't match the one specified in RemoteSecret

### DIFF
--- a/api/v1beta1/remotesecret_types.go
+++ b/api/v1beta1/remotesecret_types.go
@@ -102,8 +102,18 @@ type RemoteSecret struct {
 
 var secretTypeMismatchError = errors.New("the type of upload secret and remote secret spec do not match")
 
+// ValidateUploadSecretType checks weather the uploadSecret type matches the RemoteSecret type.
+// The function is in the api package because it extends the contract of the CRD.
+// In the future the function can be extended to validate other fields.
 func (rs *RemoteSecret) ValidateUploadSecretType(uploadSecret *corev1.Secret) error {
-	if uploadSecret.Type != rs.Spec.Secret.Type {
+	defaultize := func(secretType corev1.SecretType) corev1.SecretType {
+		if secretType == "" {
+			return corev1.SecretTypeOpaque
+		}
+		return secretType
+	}
+
+	if defaultize(uploadSecret.Type) != defaultize(rs.Spec.Secret.Type) {
 		return fmt.Errorf("%w, uploadSecret: %s, remoteSecret: %s", secretTypeMismatchError, uploadSecret.Type, rs.Spec.Secret.Type)
 	}
 	return nil

--- a/api/v1beta1/remotesecret_types.go
+++ b/api/v1beta1/remotesecret_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"errors"
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -95,6 +98,15 @@ type RemoteSecret struct {
 
 	Spec   RemoteSecretSpec   `json:"spec,omitempty"`
 	Status RemoteSecretStatus `json:"status,omitempty"`
+}
+
+var secretTypeMismatchError = errors.New("the type of upload secret and remote secret spec do not match")
+
+func (rs *RemoteSecret) ValidateUploadSecretType(uploadSecret *corev1.Secret) error {
+	if uploadSecret.Type != rs.Spec.Secret.Type {
+		return fmt.Errorf("%w, uploadSecret: %s, remoteSecret: %s", secretTypeMismatchError, uploadSecret.Type, rs.Spec.Secret.Type)
+	}
+	return nil
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/remotesecret_types_test.go
+++ b/api/v1beta1/remotesecret_types_test.go
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestValidateUploadSecretType(t *testing.T) {
+	test := func(rsType, uploadType corev1.SecretType, shouldError bool) {
+		remoteSecret := &RemoteSecret{
+			Spec: RemoteSecretSpec{
+				Secret: LinkableSecretSpec{
+					Type: rsType,
+				},
+			},
+		}
+		uploadSecret := &corev1.Secret{
+			Type: uploadType,
+		}
+		err := remoteSecret.ValidateUploadSecretType(uploadSecret)
+		if shouldError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+
+	t.Run("types match", func(t *testing.T) {
+		test("", "", false)
+		test("", corev1.SecretTypeOpaque, false)
+		test(corev1.SecretTypeOpaque, "", false)
+		test("foo", "foo", false)
+	})
+
+	t.Run("types do not match", func(t *testing.T) {
+		test("", corev1.SecretTypeDockercfg, true)
+		test(corev1.SecretTypeDockercfg, corev1.SecretTypeOpaque, true)
+		test(corev1.SecretTypeBasicAuth, corev1.SecretTypeSSHAuth, true)
+		test("rick", "morty", true)
+	})
+
+}


### PR DESCRIPTION
### What does this PR do?
If the uploadSecret type does not match the secret type of RemoteSecret:
1. data is not uploaded and RS remain in waiting data state
2. the upload secret is deleted
3. Error event is created explaining the issue.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->
![image](https://github.com/redhat-appstudio/remote-secret/assets/73115616/636e199f-1d76-46f2-8bde-78341cf355d7)


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-499

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
RS operator image: `quay.io/pbaran/rs:SVPI-499-UX`

1. Create RemoteSecret:
```shell
cat <<EOF | kubectl create -n "default" -f -
apiVersion: appstudio.redhat.com/v1beta1
kind: RemoteSecret
metadata:
  name: remote-secret
spec:
  secret:
    generateName: some-secret-
    type: kubernetes.io/dockercfg
  targets:
  - namespace: target
EOF
```
2. Create upload secret with different type:
```shell
cat <<EOF | kubectl create -n "default" -f -
apiVersion: v1
kind: Secret
metadata:
  name: remote-secret-secret
  labels:
    appstudio.redhat.com/upload-secret: remotesecret
  annotations:
    appstudio.redhat.com/remotesecret-name: remote-secret
type: Opaque
stringData:
  a: b
  c: d
EOF
```
3. Observe that RS stays in awaiting token data and `kubectl get events` show event similar to screenshot.