### PR TITLE
Introduce the possibility of running the controller with profiling on

### DIFF
--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -37,6 +37,7 @@ The `remote-secret-controller-manager-environment-config` config map contains co
 | --file-request-ttl                                    | FILEREQUESTLIFETIMEDURATION    | 30m                      | File content request lifetime in hours, minutes or seconds.                                                                                                                                                                        |
 | --token-match-policy                                  | TOKENMATCHPOLICY               | any                      | The policy to match the token against the binding. Options:  'any', 'exact'."`                                                                                                                                                     |
 | --deletion-grace-period                               | DELETIONGRACEPERIOD            | 2s                       | The grace period between a condition for deleting a binding or token is satisfied and the token or binding actually being deleted.                                                                                                 |
+| --expose-profiling                                    | EXPOSEPROFILING                | false                    | Whether or not expose the profiling information on the metrics endpoint under /debug/pprof path.                                                                                                                                   |
 
 
 ## Token Storage

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -122,3 +122,19 @@ On Minikube use:
 ```
 make deploy_minikube IMG_BASE=<MY-CUSTOM-IMAGE-BASE> TAG_NAME=<MY-CUSTOM-TAG-NAME>
 ```
+
+## Profiling
+
+It is possible to run the operator locally with the pprof data exposed on the metrics endpoint. To run the operator locally with profiling on, you can:
+
+```
+make run EXPOSEPROFILING=true
+```
+
+The profiling data is then going to be present on `localhost:8080/debug/pprof`.
+
+You can use the `pprof` tool to examine the collected profiling data, e.g.:
+
+```
+go tool prof -http :6006 http://localhost:8080/debug/pprof/heap
+```

--- a/hack/profile-load.sh
+++ b/hack/profile-load.sh
@@ -57,7 +57,7 @@ rm pid.file
 echo "collecting the heap info for $PROFILING_TIME consecutive seconds"
 
 for i in $(seq 1 $PROFILING_TIME); do
-	curl --retry 5 --retry-connrefused --retry-delay 1 -o heap-$i.out "http://localhost:8080/debug/pprof/heap" &
+	curl --retry 5 --retry-connrefused --retry-delay 1 -o heap-$i.out "http://localhost:8080/debug/pprof/heap"
 	sleep 1
 done
 
@@ -67,7 +67,7 @@ echo "deleting all the created remote secrets"
 
 kubectl delete remotesecret -n default -l perf-test=true
 
-curl -o heap-after.out "http://localhost:8080/debug/pprof/heap" &
+curl -o heap-after.out "http://localhost:8080/debug/pprof/heap"
 
 echo "killing the remote secret controller with PID $PID"
 kill $PID

--- a/hack/profile-load.sh
+++ b/hack/profile-load.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# This script creates a number of remote secrets with data and then starts the controller using `make run` with profiling enabled
+# and collects heap profiles each second for a number of times. This can be used to estimate the memory consumption during the startup
+# of the controller.
+
+NOF_RESOURCES=500
+PROFILING_TIME=60
+
+THIS_DIR="$(dirname "$(realpath "$0")")"
+
+echo "creating $NOF_RESOURCES remote secrets with data"
+
+for i in $(seq 1 $NOF_RESOURCES); do
+	kubectl apply -f - <<EOF
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: perf-rs-$i
+  namespace: default
+  labels:
+    perf-test: "true"
+spec:
+  secret: {}
+  targets:
+  - namespace: default
+EOF
+
+	kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: upload-$i
+  namespace: default
+  labels:
+    appstudio.redhat.com/upload-secret: remotesecret
+  annotations:
+    appstudio.redhat.com/remotesecret-name: perf-rs-$i
+stringData:
+  k1: v1
+  k2: v2
+EOF
+
+done
+
+echo "starting the remote secret controller"
+
+sh -c 'echo $$ > pid.file; exec make -C '"$THIS_DIR"'/.. run EXPOSEPROFILING=true' &
+until [ -f pid.file ]; do
+	sleep 1
+done
+while [ -z $PID ]; do
+	PID=$(cat pid.file)
+done
+rm pid.file
+
+echo "collecting the heap info for $PROFILING_TIME consecutive seconds"
+
+for i in $(seq 1 $PROFILING_TIME); do
+	curl --retry 5 --retry-connrefused --retry-delay 1 -o heap-$i.out "http://localhost:8080/debug/pprof/heap" &
+	sleep 1
+done
+
+sleep 10
+
+echo "deleting all the created remote secrets"
+
+kubectl delete remotesecret -n default -l perf-test=true
+
+curl -o heap-after.out "http://localhost:8080/debug/pprof/heap" &
+
+echo "killing the remote secret controller with PID $PID"
+kill $PID

--- a/pkg/cmd/cli.go
+++ b/pkg/cmd/cli.go
@@ -37,6 +37,7 @@ type CommonCliArgs struct {
 	ConfigFile        string           `arg:"--config-file, env" default:"/etc/spi/config.yaml" help:"The location of the configuration file."`
 	AllowInsecureURLs bool             `arg:"--allow-insecure-urls, env" default:"false" help:"Whether is allowed or not to use insecure http URLs in service provider or vault configurations."`
 	TokenStorage      TokenStorageType `arg:"--tokenstorage, env" default:"vault" help:"The type of the token storage. Supported types: 'vault', 'aws' (experimental)."`
+	ExposeProfiling   bool             `arg:"--expose-profiling, env" default:"false" help:"whether to expose the /debug/pprof/ endpoint on the metrics bind address with the pprof profiling data."`
 	vaultcli.VaultCliArgs
 	awscli.AWSCliArgs
 }


### PR DESCRIPTION
### What does this PR do?
Introduce the possibility of running the controller with profiling on :8080/debug/pprof to enable remote profiling using the pprof tool.

### What issues does this PR fix or reference?
none

### How to test this PR?
run the `hack/profile-load.sh` script and examine the created heap profiles using the pprof tool.

First install pprof by running 
```
go install github.com/google/pprof@latest
```

You can then inspect the heap profiles by running e.g.:

```
go tool pprof -http :6006 heap-15.out
```

This will open browser window pointing to localhost:6006 where you can see the collected data in a number of visualizations.