### PR TITLE
Completely remove the UID from storage object ID

### DIFF
--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/integration_tests/secretstorage_acceptance_test.go
+++ b/integration_tests/secretstorage_acceptance_test.go
@@ -166,7 +166,7 @@ var (
 func refreshTestData(t *testing.T) {
 
 	random, _, _ := strings.Cut(string(uuid.NewUUID()), "-")
-	secretId = secretstorage.SecretID{Uid: uuid.NewUUID(), Name: "secret" + random, Namespace: "ns" + random}
+	secretId = secretstorage.SecretID{Name: "secret" + random, Namespace: "ns" + random}
 	testData := map[string]any{
 		"username":     "testUsername-" + random,
 		"accessToken":  "testAccessToken-" + random,

--- a/pkg/secretstorage/secretstorage.go
+++ b/pkg/secretstorage/secretstorage.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,18 +28,16 @@ import (
 // be more explicit and forward-compatible should any changes to this struct arise in
 // the future.
 type SecretID struct {
-	Uid       types.UID
 	Name      string
 	Namespace string
 }
 
 // String returns the string representation of the SecretID.
 func (s SecretID) String() string {
-	return fmt.Sprintf("%s/%s [uid=%s]", s.Namespace, s.Name, s.Uid)
+	return fmt.Sprintf("%s/%s", s.Namespace, s.Name)
 }
 
 var NotFoundError = errors.New("not found")
-var ErrNoUid = errors.New("kubernetes object does not have UID")
 
 // SecretStorage is a generic storage mechanism for storing secret data keyed by the SecretID.
 type SecretStorage interface {
@@ -93,11 +90,7 @@ type DefaultTypedSecretStorage[ID any, D any] struct {
 
 // ObjectToID converts given Kubernetes object to SecretID based on the name and namespace.
 func ObjectToID[O client.Object](obj O) (*SecretID, error) {
-	if obj.GetUID() == "" {
-		return nil, fmt.Errorf("failed to convert object '%s/%s' to secret storage ID: %w", obj.GetNamespace(), obj.GetName(), ErrNoUid)
-	}
 	return &SecretID{
-		Uid:       obj.GetUID(),
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),
 	}, nil

--- a/pkg/secretstorage/secretstorage_test.go
+++ b/pkg/secretstorage/secretstorage_test.go
@@ -22,7 +22,6 @@ import (
 	api "github.com/redhat-appstudio/remote-secret/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 )
 
@@ -160,22 +159,7 @@ func TestObjectToId(t *testing.T) {
 	assert.NotNil(t, id)
 	assert.Equal(t, id.Name, "test-n")
 	assert.Equal(t, id.Namespace, "test-ns")
-	assert.Equal(t, id.Uid, types.UID("test-uid"))
 	assert.NoError(t, err)
-}
-
-func TestObjectToIdNoUid(t *testing.T) {
-	token := &api.RemoteSecret{
-		ObjectMeta: v1.ObjectMeta{
-			Namespace: "test-ns",
-			Name:      "test-n",
-		},
-	}
-
-	id, err := ObjectToID(token)
-
-	assert.Nil(t, id)
-	assert.Error(t, err)
 }
 
 type CallsRecord[K any] struct {

--- a/pkg/secretstorage/vaultstorage/vault_login_test.go
+++ b/pkg/secretstorage/vaultstorage/vault_login_test.go
@@ -55,7 +55,6 @@ func TestVaultLogin_Renewal(t *testing.T) {
 	assert.NotEqual(t, origToken, ts.client.Token())
 
 	secretId := secretstorage.SecretID{
-		Uid:       "test-uid",
 		Name:      "test",
 		Namespace: "test",
 	}


### PR DESCRIPTION
### What does this PR do?
Completely remove the UID from storage object ID as it is not more used for migrations or anything.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
precondition to https://issues.redhat.com/browse/SVPI-569

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
No functional changes expected