### PR TITLE
Add validator to check environment label and annotation are mutually exclusive

### DIFF
--- a/api/v1beta1/constants.go
+++ b/api/v1beta1/constants.go
@@ -38,4 +38,8 @@ const (
 	// RemoteSecretDeletedKeysAnnotation should be placed on an upload secret if the user want to remove some keys from the secret data of an already existing remote secret. It
 	// contains the comma-separated list of keys that should be removed.
 	RemoteSecretDeletedKeysAnnotation = "appstudio.redhat.com/remotesecret-deleted-keys"
+
+	// EnvironmentNameLabelOrAnnotation is used to specify the name of the environment that the remote secret is associated with.
+	// If used as an annotation, it is allows multiple values. If used as a label, it is a single value. Usage is mutually exclusive between label and annotation.
+	EnvironmentNameLabelOrAnnotation = "appstudio.redhat.com/environment"
 )

--- a/api/v1beta1/remotesecret_types_test.go
+++ b/api/v1beta1/remotesecret_types_test.go
@@ -16,8 +16,9 @@ package v1beta1
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -202,11 +202,6 @@ func (r *RemoteSecretReconciler) Reconcile(ctx context.Context, req reconcile.Re
 		return ctrl.Result{}, fmt.Errorf("failed to get the RemoteSecret: %w", err)
 	}
 
-	if err := remoteSecret.ValidateEnvironment(); err != nil {
-		lg.Error(err, "remote secret environment validation failed")
-		return ctrl.Result{}, fmt.Errorf("remote secret format error: %w", err)
-	}
-
 	finalizationResult, err := r.finalizers.Finalize(ctx, remoteSecret)
 	if err != nil {
 		// if the finalization fails, the finalizer stays in place, and so we don't want any repeated attempts until

--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -202,6 +202,11 @@ func (r *RemoteSecretReconciler) Reconcile(ctx context.Context, req reconcile.Re
 		return ctrl.Result{}, fmt.Errorf("failed to get the RemoteSecret: %w", err)
 	}
 
+	if err := remoteSecret.ValidateEnvironment(); err != nil {
+		lg.Error(err, "remote secret environment validation failed")
+		return ctrl.Result{}, fmt.Errorf("remote secret format error: %w", err)
+	}
+
 	finalizationResult, err := r.finalizers.Finalize(ctx, remoteSecret)
 	if err != nil {
 		// if the finalization fails, the finalizer stays in place, and so we don't want any repeated attempts until


### PR DESCRIPTION
### What does this PR do?
${TTILE}

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-613 (validation part)

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
-->

Try to create inconsistent RS:

```
apiVersion: appstudio.redhat.com/v1beta1
kind: RemoteSecret
metadata:
  name: demo-secret
  namespace: default
  labels:
    appstudio.redhat.com/application: rs-sample
    appstudio.redhat.com/environment: default
  annotations:
    appstudio.redhat.com/environment: foo, bar
spec:
  secret:
    name: demo-secret-from-remote
    type: Opaque
```

Must got an error:
```
Error from server (target environments format error: the following annotation and label must not be set at the same time: appstudio.redhat.com/environment): error when creating "remotesecret.yaml": admission webhook "vremotesecret.kb.io" denied the request: target environments format error: the following annotation and label must not be set at the same time: appstudio.redhat.com/environment
```
