### PR TITLE
Having dataFrom.name without "omitempty" forced the field to always be present in the output

### DIFF
--- a/api/v1beta1/remotesecret_types.go
+++ b/api/v1beta1/remotesecret_types.go
@@ -268,7 +268,7 @@ const (
 )
 
 type RemoteSecretDataFrom struct {
-	Name      string `json:"name"`
+	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 }
 

--- a/config/crd/bases/appstudio.redhat.com_remotesecrets.yaml
+++ b/config/crd/bases/appstudio.redhat.com_remotesecrets.yaml
@@ -46,8 +46,6 @@ spec:
                 type: string
               namespace:
                 type: string
-            required:
-            - name
             type: object
           kind:
             description: 'Kind is a string value representing the REST resource this


### PR DESCRIPTION
### What does this PR do?
`$TITLE`

This is a small followup PR for https://issues.redhat.com/browse/SVPI-553
to fix the output of the RemoteSecret with an empty dataFrom.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-553

### How to test this PR?
1. kubectl get remotesecret ... -o yaml
2. Check that there's no `dataFrom` in the YAML of the rs resource.