### PR TITLE
fix the Restore cache failed warning of the github actions job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,10 @@ jobs:
     env:
       OPERATOR_SDK_VERSION: v1.28.1
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
@@ -36,10 +40,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
         uses: actions/cache@v3
         id: cache-operator-sdk
@@ -120,6 +120,10 @@ jobs:
     env:
       OPERATOR_SDK_VERSION: v1.28.1
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
@@ -128,10 +132,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Check out SPI's code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### What does this PR do?
 - actions/setup-go provides module-caching feature for dependencies [from v4](https://github.com/actions/setup-go/releases/tag/v4.0.0).
- However, the cache is not working correctly in the current job configuration.
One of the example job results is https://github.com/redhat-appstudio/service-provider-integration-operator/actions/runs/6495456060 with the warning message Restore cache failed: Dependencies file is not found in /home/runner/work/viper/viper. Supported file pattern: go.sum.
Related to https://github.com/redhat-appstudio/service-provider-integration-operator/pull/739
### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
n/a

### How to test this PR?
n/a