### PR TITLE
Specify a concrete patch version of the go compiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.21.3 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
### What does this PR do?
Specify a concrete patch version of the go compiler to ensure reproducible builds by being sure about the version of the standard library used.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-660


### How to test this PR?
`make docker-build` should work.