### PR TITLE
Fix 'permission denied' error while building on podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
-WORKDIR /workspace
+WORKDIR /opt/app-root/src
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -35,7 +35,7 @@ RUN microdnf -y install shadow-utils \
 		--gid 65532 \
 		nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /opt/app-root/src/manager .
 # It is mandatory to set these labels
 LABEL description="RHTAP RemoteSecret Operator"
 LABEL io.k8s.description="RHTAP RemoteSecret Operator"


### PR DESCRIPTION
### What does this PR do?
Fixes the build error on podman:

```
[1/2] STEP 12/12: RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
command-line-arguments: go build command-line-arguments: copying /tmp/go-build2877167665/b001/exe/a.out: open manager: permission denied
Error: building at STEP "RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go": while running runtime: exit status 1
make: *** [Makefile:196: docker-build] Помилка 1

```


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
Test that `make docker-build` works fine