### PR TITLE
Revert "Ensure that target k8s client is able to connect to the turget cluster (#241)"

### DIFF
--- a/controllers/bindings/client_factory.go
+++ b/controllers/bindings/client_factory.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	api "github.com/redhat-appstudio/remote-secret/api/v1beta1"
 	"github.com/redhat-appstudio/remote-secret/pkg/logs"
 	auth "k8s.io/api/authentication/v1"
@@ -44,7 +42,6 @@ var (
 	noAuthServiceAccountFound                         = errors.New("No service account labeled with '" + api.RemoteSecretAuthServiceAccountLabel + "' was found that could be used to authenticate deployments to targets in the local cluster")
 	onlyOneAuthServiceAccountPerNamespaceAllowed      = errors.New("there can be only one service account labeled with '" + api.RemoteSecretAuthServiceAccountLabel + "' in a namespace")
 	noKubeConfigSpecifiedForConnectionToRemoteCluster = errors.New("a secret with kubeconfig with credentials for connecting to a remote cluster is required")
-	ErrorInvalidClientConfig                          = errors.New("invalid k8s client configuration")
 )
 
 // ClientFactory is a helper interface for the RemoteSecretReconciler that creates clients that are able to deploy to remote secret targets. The default (and only)
@@ -174,6 +171,7 @@ func (cf *CachingClientFactory) GetClient(ctx context.Context, currentNamespace 
 		if cf.ClientConfigurationInitializer != nil {
 			cf.ClientConfigurationInitializer(cfg, &opts)
 		}
+
 		cl, err = client.New(cfg, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct the kubernetes client: %w", err)
@@ -188,11 +186,6 @@ func (cf *CachingClientFactory) GetClient(ctx context.Context, currentNamespace 
 			ttl = cf.MaxClientCacheTTL
 		}
 
-		_, err = cl.(client.Client).RESTMapper().ResourcesFor(schema.GroupVersionResource{Version: "v1"})
-		if err != nil {
-			log.FromContext(ctx).Info("Not able to list available resources with target k8s client", "host", cfg.Host)
-			return nil, ErrorInvalidClientConfig
-		}
 		cf.cache.Set(key, cl, ttl)
 	}
 

--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -452,7 +452,7 @@ func (r *RemoteSecretReconciler) deployToNamespace(ctx context.Context, remoteSe
 	var depErr, checkPointErr, syncErr, updateErr error
 
 	depHandler, depErr := newDependentsHandler(ctx, r.TargetClientFactory, r.RemoteSecretStorage, remoteSecret, targetSpec, targetStatus)
-	if depErr != nil && !stdErrors.Is(depErr, bindings.ErrorInvalidClientConfig) {
+	if depErr != nil {
 		debugLog.Error(depErr, "failed to construct the dependents handler")
 	}
 


### PR DESCRIPTION
### What does this PR do?
This reverts commit 670483b92b39bb0a6a5355c654a3f622d35a388a.

### Screenshot/screencast of this PR
n/a


### What issues does this PR fix or reference?
e2e tests not working with this change 
https://issues.redhat.com/browse/SVPI-651

### How to test this PR?
n/a
