### PR TITLE
Make reconcile logging optional and configurable by env var / cli arg.

### DIFF
--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -102,7 +102,7 @@ func (r *RemoteSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return
 				}
 				if r.Configuration.ReconcileLogging {
-					log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "create", "remoteSecret", client.ObjectKeyFromObject(e.Object))
+					reconcileLogger(log.FromContext(ctx)).Info("enqueing reconcile", "action", "create", "remoteSecret", client.ObjectKeyFromObject(e.Object))
 				}
 				q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(e.Object)})
 			},

--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -101,12 +101,16 @@ func (r *RemoteSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				if e.Object == nil {
 					return
 				}
-				log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "create", "remoteSecret", client.ObjectKeyFromObject(e.Object))
+				if r.Configuration.ReconcileLogging {
+					log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "create", "remoteSecret", client.ObjectKeyFromObject(e.Object))
+				}
 				q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(e.Object)})
 			},
 			UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
 				diff := cmp.Diff(e.ObjectOld, e.ObjectNew, cmpopts.IgnoreFields(api.RemoteSecret{}, "TypeMeta"))
-				log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "update", "remoteSecret", client.ObjectKeyFromObject(e.ObjectOld), "diff", diff)
+				if r.Configuration.ReconcileLogging {
+					reconcileLogger(log.FromContext(ctx)).Info("enqueing reconcile", "action", "update", "remoteSecret", client.ObjectKeyFromObject(e.ObjectOld), "diff", diff)
+				}
 				// logic copied from handler.EnqueueRequestForObject
 				if e.ObjectNew != nil {
 					q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(e.ObjectNew)})
@@ -115,13 +119,17 @@ func (r *RemoteSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 			},
 			DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
-				log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "delete", "remoteSecret", client.ObjectKeyFromObject(e.Object))
+				if r.Configuration.ReconcileLogging {
+					reconcileLogger(log.FromContext(ctx)).Info("enqueing reconcile", "action", "delete", "remoteSecret", client.ObjectKeyFromObject(e.Object))
+				}
 				if e.Object != nil {
 					q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(e.Object)})
 				}
 			},
 			GenericFunc: func(ctx context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
-				log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "generic", "remoteSecret", client.ObjectKeyFromObject(e.Object))
+				if r.Configuration.ReconcileLogging {
+					reconcileLogger(log.FromContext(ctx)).Info("enqueing reconcile", "action", "generic", "remoteSecret", client.ObjectKeyFromObject(e.Object))
+				}
 				if e.Object != nil {
 					q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(e.Object)})
 				}
@@ -129,8 +137,8 @@ func (r *RemoteSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 			reqs := linksToReconcileRequests(ctx, mgr.GetScheme(), o)
-			if len(reqs) > 0 {
-				log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "reactOnSource", "sourceKind", "secret", "source", client.ObjectKeyFromObject(o), "remoteSecrets", reqs, "reactReason", "link")
+			if r.Configuration.ReconcileLogging && len(reqs) > 0 {
+				reconcileLogger(log.FromContext(ctx)).Info("enqueing reconcile", "action", "reactOnSource", "sourceKind", "secret", "source", client.ObjectKeyFromObject(o), "remoteSecrets", reqs, "reactReason", "link")
 			}
 			return reqs
 		})).
@@ -138,8 +146,8 @@ func (r *RemoteSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 				reqs := r.findRemoteSecretForUploadSecret(o)
-				if len(reqs) > 0 {
-					log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "reactOnSource", "sourceKind", "secret", "source", client.ObjectKeyFromObject(o), "remoteSecrets", reqs, "reactReason", "dataUpload")
+				if r.Configuration.ReconcileLogging && len(reqs) > 0 {
+					reconcileLogger(log.FromContext(ctx)).Info("enqueing reconcile", "action", "reactOnSource", "sourceKind", "secret", "source", client.ObjectKeyFromObject(o), "remoteSecrets", reqs, "reactReason", "dataUpload")
 				}
 				return reqs
 			}),
@@ -149,8 +157,8 @@ func (r *RemoteSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Watches(&corev1.ServiceAccount{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 			reqs := r.findRemoteSecretsInNamespaceForAuthSA(ctx, o)
-			if len(reqs) > 0 {
-				log.FromContext(ctx, "troubleshoot", true).Info("enqueing reconcile", "action", "reactOnSource", "sourceKing", "serviceAccount", "source", client.ObjectKeyFromObject(o), "remoteSecrets", reqs, "reactReason", "authSA")
+			if r.Configuration.ReconcileLogging && len(reqs) > 0 {
+				reconcileLogger(log.FromContext(ctx)).Info("enqueing reconcile", "action", "reactOnSource", "sourceKing", "serviceAccount", "source", client.ObjectKeyFromObject(o), "remoteSecrets", reqs, "reactReason", "authSA")
 			}
 			return reqs
 		})).
@@ -236,7 +244,9 @@ func (r *RemoteSecretReconciler) Reconcile(ctx context.Context, req reconcile.Re
 	var origRemoteSecret *api.RemoteSecret
 	defer func() {
 		diff := cmp.Diff(origRemoteSecret, remoteSecret, cmpopts.IgnoreFields(api.RemoteSecret{}, "TypeMeta"))
-		lg.Info("reconcile complete", "troubleshoot", true, "error", err, "diff", diff)
+		if r.Configuration.ReconcileLogging {
+			reconcileLogger(lg).Info("reconcile complete", "error", err, "diff", diff)
+		}
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, remoteSecret); err != nil {
@@ -803,4 +813,8 @@ func (f *remoteSecretLinksFinalizer) createErrorEvent(ctx context.Context, rs cl
 		return fmt.Errorf("failed to create the cleanup failure event(s): %w", retErr)
 	}
 	return nil
+}
+
+func reconcileLogger(lg logr.Logger) logr.Logger {
+	return lg.WithValues("diagnostics", "reconcile")
 }

--- a/main.go
+++ b/main.go
@@ -165,12 +165,13 @@ func main() {
 }
 
 func LoadFrom(args *cmd.OperatorCliArgs) (config.OperatorConfiguration, error) {
-	ret := config.OperatorConfiguration{}
+	ret := config.OperatorConfiguration{
+		ReconcileLogging: args.ReconcileLogging,
+	}
 	return ret, nil
 }
 
 func createManager(lg logr.Logger, args cmd.OperatorCliArgs) (manager.Manager, error) {
-
 	restConfig := ctrl.GetConfigOrDie()
 	disableHTTP2 := func(c *tls.Config) {
 		if !args.DisableHTTP2 {

--- a/pkg/cmd/cli.go
+++ b/pkg/cmd/cli.go
@@ -22,6 +22,7 @@ import (
 // LoggingCliArgs define the command line arguments for configuring the logging using Zap.
 type LoggingCliArgs struct {
 	ZapDevel           bool   `arg:"--zap-devel, env" default:"false" help:"Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn) Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)"`
+	ReconcileLogging   bool   `arg:"--reconcile-logging, env" default:"false" help:"When true, logs the reconciliation triggers and diffs on info level with 'diagnostics: reconcile' key/value pair."`
 	ZapEncoder         string `arg:"--zap-encoder, env" default:"" help:"Zap log encoding (‘json’ or ‘console’)"`
 	ZapLogLevel        string `arg:"--zap-log-level, env" default:"" help:"Zap Level to configure the verbosity of logging"`
 	ZapStackTraceLevel string `arg:"--zap-stacktrace-level, env" default:"" help:"Zap Level at and above which stacktraces are captured"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ type instanceIdContextKeyType struct{}
 var InstanceIdContextKey = instanceIdContextKeyType{}
 
 type OperatorConfiguration struct {
+	ReconcileLogging bool
 }
 
 const (


### PR DESCRIPTION
### What does this PR do?

Make reconcile logging optional and configurable by env var / cli arg.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-664

### How to test this PR?
1. Install remote secrets
2. Modify the `remote-secret-controller-manager-environment-config` configmap and add the `RECONCILELOGGING: "true"` entry to its data.
3. Restart the remote secret controller manager
4. Create some remote secret.
5. Notice there are log entries with `diagnostics: reconcile` key/value pair giving out info about the reconciliations of remote secrets in the cluster.