### PR TITLE
SVPI-718; prevent too much error logs on unaccessible targets

### DIFF
--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -584,13 +584,15 @@ func (ndsp *NamespaceDeploymentSyncProgress) Start(ctx context.Context, remoteSe
 
 	err := rerror.AggregateNonNilErrors(depErr, checkPointErr, ndsp.syncError)
 
-	ndsp.inconsistent = stdErrors.Is(err, bindings.DependentsInconsistencyError)
+	if deps != nil {
+		ndsp.inconsistent = stdErrors.Is(err, bindings.DependentsInconsistencyError)
 
-	if err != nil {
-		if ndsp.inconsistent {
-			debugLog.Info("encountered an inconsistency error", "error", err.Error())
-		} else {
-			debugLog.Error(err, "failed to sync the dependent objects")
+		if err != nil {
+			if ndsp.inconsistent {
+				debugLog.Info("encountered an inconsistency error", "error", err.Error())
+			} else {
+				debugLog.Error(err, "failed to sync the dependent objects")
+			}
 		}
 	}
 
@@ -622,7 +624,7 @@ func (ndsp *NamespaceDeploymentSyncProgress) FinishAndGetErrorToReport(ctx conte
 			saks[i] = client.ObjectKeyFromObject(sa)
 		}
 		debugLog.Info("successfully synced dependent objects of remote secret", "syncedSecret", client.ObjectKeyFromObject(deps.Secret), "SAs", saks)
-	} else if deps == nil {
+	} else if ndsp.depHandler != nil && deps == nil {
 		debugLog.Error(nil, "Sync of the dependent objects reported no error yet we don't have a record of the performed changes. This should not happen.")
 	}
 


### PR DESCRIPTION
### What does this PR do?
Fixes the excessive amount of errors for unreachable/invalid BYOC targets

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-718

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
 
 Create RS + credentials secret pair, apiUrl in target must be wrong/inaccessbile. :
 
 ```
 ---
kind: Secret
apiVersion: v1
metadata:
  name: test-remote-kubeconfig
  namespace: default
type: managed-gitops.redhat.com/managed-environment
data:
  kubeconfig: >-
     YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGluc2VjdXJlLXNraXAtdGxzLXZlcmlmeTogdHJ1ZQogICAgc2VydmVyOiBodHRwczovL2FwaS5jbHVzdGVyLTJzN2tnLjJzN2tnLnNhbmRib3gyMzEzLm9wZW50bGMuY29tO
jY0NDMKICBuYW1lOiBhcGktY2x1c3Rlci0yczdrZy0yczdrZy1zYW5kYm94MjMxMy1vcGVudGxjLWNvbTo2NDQzCmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBhcGktY2x1c3Rlci0yczdrZy0yczdrZy1zYW5kYm94MjMxMy1vcGVudG
xjLWNvbTo2NDQzCiAgICBuYW1lc3BhY2U6IGRlZmF1bHQKICAgIHVzZXI6IGFkbWluL2FwaS1jbHVzdGVyLTJzN2tnLTJzN2tnLXNhbmRib3gyMzEzLW9wZW50bGMtY29tOjY0NDMKICBuYW1lOiBkZWZhdWx0L2FwaS1jbHVzdGVyLTJzN2tnLTJzN2t
nLXNhbmRib3gyMzEzLW9wZW50bGMtY29tOjY0NDMvYWRtaW4KY3VycmVudC1jb250ZXh0OiBkZWZhdWx0L2FwaS1jbHVzdGVyLTJzN2tnLTJzN2tnLXNhbmRib3gyMzEzLW9wZW50bGMtY29tOjY0NDMvYWRtaW4Ka2luZDogQ29uZmlnCnByZWZlcmVu
Y2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhZG1pbi9hcGktY2x1c3Rlci0yczdrZy0yczdrZy1zYW5kYm94MjMxMy1vcGVudGxjLWNvbTo2NDQzCiAgdXNlcjoKICAgIHRva2VuOiBzaGEyNTZ+MGxwLWdSMXI0T3g2RGJpVm5xX3p2bnp4T2VreUo3MnEwU
VpYNTBmeGw1dw==

---
apiVersion: appstudio.redhat.com/v1beta1
kind: RemoteSecret
metadata:
  name: demo-secret
  namespace: default
spec:
  targets:
    - apiUrl: https://api-cluster-2s7kg-2s7kg-sandbox2313-opentlc-com:6443
      clusterCredentialsSecret: test-remote-kubeconfig
      namespace: remote
  secret:
    name: demo-secret-multiple-environment
    type: Opaque
stringData:
  username: Z2VuYQ==
  password: Z2VuYQ==
```

This must produce only INFO msg in the logs, no errors:

```
{"level":"info","ts":"2024-01-26T08:12:53.105Z","caller":"bindings/client_factory.go:194","msg":"Not able to list available resources with target k8s client","controller":"remotesecret","namespace":"default","name":"demo-secret","reconcileID":"38620a1d-e9cc-49f3-befc-3e1e59b0c6a2","host":"https://api-cluster-2s7kg-2s7kg-sandbox2313-opentlc-com:6443","error":"failed to get API group resources: unable to retrieve the complete list of server APIs: v1: Get \"https://api-cluster-2s7kg-2s7kg-sandbox2313-opentlc-com:6443/api/v1\": dial tcp: lookup api-cluster-2s7kg-2s7kg-sandbox2313-opentlc-com on 10.96.0.10:53: read udp 10.244.0.11:51368->10.96.0.10:53: i/o timeout"}
```