### PR TITLE
Revert "An attempt to split up the `deployToNamespace` method into mo…

### DIFF
--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -539,116 +539,48 @@ func (r *RemoteSecretReconciler) processTargets(ctx context.Context, remoteSecre
 // if the deployment failed. This returns an error if the deployment fails (this is recorded in the target status) OR if the update of the status in k8s fails (this is,
 // obviously, not recorded in the target status).
 func (r *RemoteSecretReconciler) deployToNamespace(ctx context.Context, remoteSecret *api.RemoteSecret, targetSpec *api.RemoteSecretTarget, targetStatus *api.TargetStatus, data *remotesecretstorage.SecretData) error {
-	ndsp := NamespaceDeploymentSyncProgress{Reconciler: r}
-
-	deps, secretSpec, reportError := ndsp.Start(ctx, remoteSecret, targetSpec, targetStatus)
-
-	updateErr := r.updateStatusWithNamespaceDeploymentResults(ctx, deps, reportError, remoteSecret, &secretSpec, targetSpec, targetStatus)
-
-	err := ndsp.FinishAndGetErrorToReport(ctx, remoteSecret, updateErr, deps)
-	if err != nil {
-		return fmt.Errorf("failed to deploy to the namespace %s: %w", targetSpec.Namespace, err)
-	}
-	return nil
-}
-
-type NamespaceDeploymentSyncProgress struct {
-	syncError    error
-	depHandler   *bindings.DependentsHandler[*api.RemoteSecret]
-	checkPoint   *bindings.CheckPoint
-	Reconciler   *RemoteSecretReconciler
-	inconsistent bool
-}
-
-// Start begins the sync progress. The returned error, if any, is to be set in the error field of the targetStatus
-func (ndsp *NamespaceDeploymentSyncProgress) Start(ctx context.Context, remoteSecret *api.RemoteSecret, targetSpec *api.RemoteSecretTarget, targetStatus *api.TargetStatus) (*bindings.Dependents, api.LinkableSecretSpec, error) {
 	debugLog := log.FromContext(ctx).V(logs.DebugLevel)
-	var depErr error
-	ndsp.depHandler, depErr = newDependentsHandler(ctx, ndsp.Reconciler.TargetClientFactory, ndsp.Reconciler.RemoteSecretStorage, remoteSecret, targetSpec, targetStatus)
+
+	var depErr, checkPointErr, syncErr, updateErr error
+
+	depHandler, depErr := newDependentsHandler(ctx, r.TargetClientFactory, r.RemoteSecretStorage, remoteSecret, targetSpec, targetStatus)
 	if depErr != nil && !stdErrors.Is(depErr, bindings.ErrorInvalidClientConfig) {
 		debugLog.Error(depErr, "failed to construct the dependents handler")
 	}
 
-	var checkPointErr error
-	if ndsp.depHandler != nil {
-		ndsp.checkPoint, checkPointErr = ndsp.depHandler.CheckPoint(ctx)
+	var checkPoint *bindings.CheckPoint
+	if depHandler != nil {
+		checkPoint, checkPointErr = depHandler.CheckPoint(ctx)
 		if checkPointErr != nil {
 			debugLog.Error(checkPointErr, "failed to construct a checkpoint to rollback to in case of target deployment error")
 		}
 	}
 
 	var deps *bindings.Dependents
-	if ndsp.depHandler != nil && checkPointErr == nil {
-		deps, _, ndsp.syncError = ndsp.depHandler.Sync(ctx, remoteSecret)
+
+	if depHandler != nil && checkPointErr == nil {
+		deps, _, syncErr = depHandler.Sync(ctx, remoteSecret)
 	}
 
-	err := rerror.AggregateNonNilErrors(depErr, checkPointErr, ndsp.syncError)
-
-	ndsp.inconsistent = stdErrors.Is(err, bindings.DependentsInconsistencyError)
-
-	if err != nil {
-		if ndsp.inconsistent {
-			debugLog.Info("encountered an inconsistency error", "error", err.Error())
-		} else {
-			debugLog.Error(err, "failed to sync the dependent objects")
-		}
-	}
-
-	var spec api.LinkableSecretSpec
-	if ndsp.depHandler != nil {
-		spec = ndsp.depHandler.Target.GetSpec()
-	}
-	return deps, spec, err //nolint: wrapcheck //wrapped at a higher level
-}
-
-// FinishAndGetErrorToReport finishes the deployment to the namespace and returns an error, if any, to be returned from the reconcile. I.e. if this
-// returns an error, the reconciliation should be retried.
-func (ndsp *NamespaceDeploymentSyncProgress) FinishAndGetErrorToReport(ctx context.Context, remoteSecret *api.RemoteSecret, updateError error, deps *bindings.Dependents) error {
-	debugLog := log.FromContext(ctx, "remoteSecret", client.ObjectKeyFromObject(remoteSecret)).V(logs.DebugLevel)
-
-	// first, let's check if we encountered a condition that should force us to revert the change we did to the dependent objects in the target.
-	if ndsp.syncError != nil || updateError != nil {
-		if ndsp.depHandler != nil && ndsp.checkPoint != nil {
-			if rerr := ndsp.depHandler.RevertTo(ctx, ndsp.checkPoint); rerr != nil {
-				debugLog.Error(rerr, "failed to revert the sync of the dependent objects of the remote secret after a failure", "syncError", ndsp.syncError, "updateError", updateError)
-			}
-		} else {
-			debugLog.Info("no checkpoint or dependency handler to use for reverting a failed sync", "syncError", ndsp.syncError, "updateError", updateError)
-		}
-	} else if debugLog.Enabled() && deps != nil {
-		// there is no sync error nor an update error. The deps should always be non-nil in that case but let's be super-paranoid.
-		saks := make([]client.ObjectKey, len(deps.ServiceAccounts))
-		for i, sa := range deps.ServiceAccounts {
-			saks[i] = client.ObjectKeyFromObject(sa)
-		}
-		debugLog.Info("successfully synced dependent objects of remote secret", "syncedSecret", client.ObjectKeyFromObject(deps.Secret), "SAs", saks)
-	} else if deps == nil {
-		debugLog.Error(nil, "Sync of the dependent objects reported no error yet we don't have a record of the performed changes. This should not happen.")
-	}
-
-	// we want the inconsistency errors to be noted by the user, but we don't want them to
-	// bubble up and cause reconcile retries
-	syncError := ndsp.syncError
-	if ndsp.inconsistent {
-		syncError = nil
-	}
-
-	return rerror.AggregateNonNilErrors(syncError, updateError) //nolint: wrapcheck // wrapped at a higher level
-}
-
-func (r *RemoteSecretReconciler) updateStatusWithNamespaceDeploymentResults(ctx context.Context, deps *bindings.Dependents, syncProgressError error, remoteSecret *api.RemoteSecret, secretSpec *api.LinkableSecretSpec, targetSpec *api.RemoteSecretTarget, targetStatus *api.TargetStatus) error {
 	targetStatus.ApiUrl = targetSpec.ApiUrl
 	targetStatus.ClusterCredentialsSecret = targetSpec.ClusterCredentialsSecret
+
+	inconsistent := false
+
+	// construct ExpectedSecret from overriding secret definition in target or if there is none, definition of secret in RS spec.
+	secretKey := &api.TargetSecretKey{}
+	if targetSpec.Secret != nil && (targetSpec.Secret.Name != "" || targetSpec.Secret.GenerateName != "") {
+		secretKey.Name = targetSpec.Secret.Name
+		secretKey.GenerateName = targetSpec.Secret.GenerateName
+	} else {
+		secretKey.Name = remoteSecret.Spec.Secret.Name
+		secretKey.GenerateName = remoteSecret.Spec.Secret.GenerateName
+	}
 
 	if deps != nil {
 		targetStatus.Namespace = deps.Secret.Namespace
 		targetStatus.DeployedSecret = &api.DeployedSecretStatus{}
 		targetStatus.DeployedSecret.Name = deps.Secret.Name
-		// if we got here, the secret will have had the labels/annos from the spec applied.
-		// We don't want to report the full set of the labels/annos though because those will contain
-		// more than just the requested in the spec.
-		targetStatus.DeployedSecret.Labels = secretSpec.Labels
-		targetStatus.DeployedSecret.Annotations = secretSpec.Annotations
 
 		targetStatus.ServiceAccountNames = make([]string, len(deps.ServiceAccounts))
 		for i, sa := range deps.ServiceAccounts {
@@ -656,21 +588,26 @@ func (r *RemoteSecretReconciler) updateStatusWithNamespaceDeploymentResults(ctx 
 		}
 		targetStatus.Error = ""
 
+		// so let's use it to remember the labels and annotations that we are explicitly setting on the secret so that we can properly
+		// depTargetSpec contains the labels and annotations derived from the spec of the remote secret (taking into account the overrides)
+		// manage them in case of changes.
+		// The `deps` contains the actual secret as it exists in the target, which will contain more labels and annos (either set by someone
+		// else for the pre-existing secrets or the tracking labels and annos set by the dep handler).
+		depTargetSpec := depHandler.Target.GetSpec()
+		targetStatus.DeployedSecret.Labels = depTargetSpec.Labels
+		targetStatus.DeployedSecret.Annotations = depTargetSpec.Annotations
 		targetStatus.ExpectedSecret = nil
 	} else {
 		targetStatus.Namespace = targetSpec.Namespace
 		targetStatus.DeployedSecret = nil
-		targetStatus.ExpectedSecret = &api.TargetSecretKey{
-			Name:         secretSpec.Name,
-			GenerateName: secretSpec.GenerateName,
-		}
+		targetStatus.ExpectedSecret = secretKey
 		targetStatus.ServiceAccountNames = []string{}
-	}
-
-	if syncProgressError != nil {
-		targetStatus.Error = syncProgressError.Error()
-	} else {
-		targetStatus.Error = ""
+		// finalizer depends on this being non-empty only in situations where we never deployed anything to the
+		// target.
+		targetStatus.Error = rerror.AggregateNonNilErrors(depErr, checkPointErr, syncErr).Error()
+		if stdErrors.Is(syncErr, bindings.DependentsInconsistencyError) {
+			inconsistent = true
+		}
 	}
 
 	// keep the backwards-compatibility for users that use this field
@@ -680,7 +617,45 @@ func (r *RemoteSecretReconciler) updateStatusWithNamespaceDeploymentResults(ctx 
 		targetStatus.SecretName = "" //nolint:staticcheck // SA1019 - this deprecated field needs to be set
 	}
 
-	return r.Client.Status().Update(ctx, remoteSecret) //nolint: wrapcheck //wrapped at a higher level
+	updateErr = r.Client.Status().Update(ctx, remoteSecret)
+	if syncErr != nil || updateErr != nil {
+		if syncErr != nil {
+			if inconsistent {
+				debugLog.Info("encountered an inconsistency error", "error", syncErr.Error())
+			} else {
+				debugLog.Error(syncErr, "failed to sync the dependent objects")
+			}
+		}
+
+		if updateErr != nil {
+			debugLog.Error(updateErr, "failed to update the status with the info about dependent objects")
+		}
+		if depHandler != nil && checkPoint != nil {
+			if rerr := depHandler.RevertTo(ctx, checkPoint); rerr != nil {
+				debugLog.Error(rerr, "failed to revert the sync of the dependent objects of the remote secret after a failure", "statusUpdateError", updateErr, "syncError", syncErr)
+			}
+		} else {
+			debugLog.Info("no checkpoint or depHandler to revert to", "depHandler", depHandler, "checkPoint", checkPoint)
+		}
+	} else if debugLog.Enabled() && depErr == nil && checkPointErr == nil {
+		saks := make([]client.ObjectKey, len(deps.ServiceAccounts))
+		for i, sa := range deps.ServiceAccounts {
+			saks[i] = client.ObjectKeyFromObject(sa)
+		}
+		debugLog.Info("successfully synced dependent objects of remote secret", "remoteSecret", client.ObjectKeyFromObject(remoteSecret), "syncedSecret", client.ObjectKeyFromObject(deps.Secret), "SAs", saks)
+	}
+
+	// we want the inconsistency errors to be noted by the user, but we don't want them to
+	// bubble up and cause reconcile retries
+	if inconsistent {
+		syncErr = nil
+	}
+	err := rerror.AggregateNonNilErrors(syncErr, updateErr)
+	if err != nil {
+		err = fmt.Errorf("failed to deploy to the namespace %s: %w", targetSpec.Namespace, err)
+	}
+
+	return err
 }
 
 func (r *RemoteSecretReconciler) deleteFromNamespace(ctx context.Context, remoteSecret *api.RemoteSecret, statusTargetIndex remotesecrets.StatusTargetIndex) error {

--- a/pkg/rerror/reconcile_error.go
+++ b/pkg/rerror/reconcile_error.go
@@ -71,7 +71,3 @@ func (ae *AggregatedError) Error() string {
 func (ae *AggregatedError) HasErrors() bool {
 	return len(ae.errors) > 0
 }
-
-func (ae *AggregatedError) Unwrap() []error {
-	return ae.errors
-}

--- a/pkg/rerror/reconcile_error_test.go
+++ b/pkg/rerror/reconcile_error_test.go
@@ -69,10 +69,3 @@ func TestAggregateNonNilErrors(t *testing.T) {
 		assert.Equal(t, "1, 2", agg.Error())
 	})
 }
-
-func TestAggregatedError_Unwrap(t *testing.T) {
-	sourceError := errors.New("source")
-	e := NewAggregatedError(errors.New("a"), sourceError, errors.New("c"))
-
-	assert.True(t, errors.Is(e, sourceError))
-}


### PR DESCRIPTION
### What does this PR do?

This reverts commit d5b461a24c9cf416e478d2b11f21aff9e3e659e4.
as it is introduces some other buggy behavior.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-718
https://issues.redhat.com/browse/SVPI-741

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
 Create RS + credentials secret pair, apiUrl in target must be wrong/inaccessbile. :
 
 ```
 ---
kind: Secret
apiVersion: v1
metadata:
  name: test-remote-kubeconfig
  namespace: default
type: managed-gitops.redhat.com/managed-environment
data:
  kubeconfig: >-
     YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGluc2VjdXJlLXNraXAtdGxzLXZlcmlmeTogdHJ1ZQogICAgc2VydmVyOiBodHRwczovL2FwaS5jbHVzdGVyLTJzN2tnLjJzN2tnLnNhbmRib3gyMzEzLm9wZW50bGMuY29tO
jY0NDMKICBuYW1lOiBhcGktY2x1c3Rlci0yczdrZy0yczdrZy1zYW5kYm94MjMxMy1vcGVudGxjLWNvbTo2NDQzCmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBhcGktY2x1c3Rlci0yczdrZy0yczdrZy1zYW5kYm94MjMxMy1vcGVudG
xjLWNvbTo2NDQzCiAgICBuYW1lc3BhY2U6IGRlZmF1bHQKICAgIHVzZXI6IGFkbWluL2FwaS1jbHVzdGVyLTJzN2tnLTJzN2tnLXNhbmRib3gyMzEzLW9wZW50bGMtY29tOjY0NDMKICBuYW1lOiBkZWZhdWx0L2FwaS1jbHVzdGVyLTJzN2tnLTJzN2t
nLXNhbmRib3gyMzEzLW9wZW50bGMtY29tOjY0NDMvYWRtaW4KY3VycmVudC1jb250ZXh0OiBkZWZhdWx0L2FwaS1jbHVzdGVyLTJzN2tnLTJzN2tnLXNhbmRib3gyMzEzLW9wZW50bGMtY29tOjY0NDMvYWRtaW4Ka2luZDogQ29uZmlnCnByZWZlcmVu
Y2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhZG1pbi9hcGktY2x1c3Rlci0yczdrZy0yczdrZy1zYW5kYm94MjMxMy1vcGVudGxjLWNvbTo2NDQzCiAgdXNlcjoKICAgIHRva2VuOiBzaGEyNTZ+MGxwLWdSMXI0T3g2RGJpVm5xX3p2bnp4T2VreUo3MnEwU
VpYNTBmeGw1dw==

---
apiVersion: appstudio.redhat.com/v1beta1
kind: RemoteSecret
metadata:
  name: demo-secret
  namespace: default
spec:
  targets:
    - apiUrl: https://api-cluster-2s7kg-2s7kg-sandbox2313-opentlc-com:6443
      clusterCredentialsSecret: test-remote-kubeconfig
      namespace: remote
  secret:
    name: demo-secret-multiple-environment
    type: Opaque
stringData:
  username: Z2VuYQ==
  password: Z2VuYQ==
```

This must produce only INFO msg in the logs, no errors:

```
{"level":"info","ts":"2024-01-26T08:12:53.105Z","caller":"bindings/client_factory.go:194","msg":"Not able to list available resources with target k8s client","controller":"remotesecret","namespace":"default","name":"demo-secret","reconcileID":"38620a1d-e9cc-49f3-befc-3e1e59b0c6a2","host":"https://api-cluster-2s7kg-2s7kg-sandbox2313-opentlc-com:6443","error":"failed to get API group resources: unable to retrieve the complete list of server APIs: v1: Get \"https://api-cluster-2s7kg-2s7kg-sandbox2313-opentlc-com:6443/api/v1\": dial tcp: lookup api-cluster-2s7kg-2s7kg-sandbox2313-opentlc-com on 10.96.0.10:53: read udp 10.244.0.11:51368->10.96.0.10:53: i/o timeout"}
```


Restart the remote-secret deployment. There must be no reconcillation loops visible with error messages repeating.